### PR TITLE
Absolute offset in replay actions

### DIFF
--- a/slider/replay.py
+++ b/slider/replay.py
@@ -25,9 +25,7 @@ class Action:
 
     Parameters
     ----------
-    rel_offset : timedelta
-        The offset since the previous action.
-    abs_offset : timedelta
+    offset : timedelta
         The offset since the beginning of the song.
     position : Position
         The position of the cursor.
@@ -40,9 +38,8 @@ class Action:
     mouse2 : bool
         is the second mouse button pressed?
     """
-    def __init__(self, rel_offset, abs_offset, position, key1, key2, mouse1, mouse2):
-        self.rel_offset = rel_offset
-        self.abs_offset = abs_offset
+    def __init__(self, offset, position, key1, key2, mouse1, mouse2):
+        self.offset = offset
         self.position = position
         self.key1 = key1
         self.key2 = key2
@@ -137,17 +134,15 @@ def _consume_actions(buffer):
     decompressed_data = lzma.decompress(compressed_data)
 
     out = []
-    abs_offset = 0
+    offset = 0
     for raw_action in decompressed_data.split(b','):
         if not raw_action:
             continue
         raw_offset, x, y, raw_action_mask = raw_action.split(b'|')
         action_mask = ActionBitMask.unpack(int(raw_action_mask))
-        rel_offset = int(raw_offset)
-        abs_offset += rel_offset
+        offset += int(raw_offset)
         out.append(Action(
-            datetime.timedelta(milliseconds=rel_offset),
-            datetime.timedelta(milliseconds=abs_offset),
+            datetime.timedelta(milliseconds=offset),
             Position(float(x), float(y)),
             action_mask['m1'],
             action_mask['m2'],

--- a/slider/replay.py
+++ b/slider/replay.py
@@ -25,8 +25,10 @@ class Action:
 
     Parameters
     ----------
-    offset : timedelta
+    rel_offset : timedelta
         The offset since the previous action.
+    abs_offset : timedelta
+        The offset since the beginning of the song.
     position : Position
         The position of the cursor.
     key1 : bool

--- a/slider/replay.py
+++ b/slider/replay.py
@@ -38,8 +38,9 @@ class Action:
     mouse2 : bool
         is the second mouse button pressed?
     """
-    def __init__(self, offset, position, key1, key2, mouse1, mouse2):
-        self.offset = offset
+    def __init__(self, rel_offset, abs_offset, position, key1, key2, mouse1, mouse2):
+        self.rel_offset = rel_offset
+        self.abs_offset = abs_offset
         self.position = position
         self.key1 = key1
         self.key2 = key2
@@ -134,13 +135,17 @@ def _consume_actions(buffer):
     decompressed_data = lzma.decompress(compressed_data)
 
     out = []
+    abs_offset = 0
     for raw_action in decompressed_data.split(b','):
         if not raw_action:
             continue
-        offset, x, y, raw_action_mask = raw_action.split(b'|')
+        raw_offset, x, y, raw_action_mask = raw_action.split(b'|')
         action_mask = ActionBitMask.unpack(int(raw_action_mask))
+        rel_offset = int(raw_offset)
+        abs_offset += rel_offset
         out.append(Action(
-            datetime.timedelta(milliseconds=int(offset)),
+            datetime.timedelta(milliseconds=rel_offset),
+            datetime.timedelta(milliseconds=abs_offset),
             Position(float(x), float(y)),
             action_mask['m1'],
             action_mask['m2'],

--- a/slider/replay.py
+++ b/slider/replay.py
@@ -147,6 +147,7 @@ def _consume_actions(buffer):
             action_mask['k1'],
             action_mask['k2'],
         ))
+    return out
 
 
 class Replay:


### PR DESCRIPTION
I needed the cumulative offset for each Action in the replay and thought it was probably a fairly common requirement.

I also fixed a bug where the actions weren't even being added to the replay because the function wasn't returning.

Not sure about the names though, they were the best I could come up with. Also isn't backwards compatible but since the actions weren't even being added to the replay I think we can probably assume no one was using them XD.