### PR TITLE
ENH: Added hitwindows for accuracies other than perfect

### DIFF
--- a/slider/mod.py
+++ b/slider/mod.py
@@ -147,18 +147,18 @@ def circle_radius(cs):
     return (512 / 16) * (1 - 0.7 * (cs - 5) / 5)
 
 
-class HitWindows(namedtuple('HitWindows', 'perfect, good, bad')):
+class HitWindows(namedtuple('HitWindows', 'hit_300, hit_100, hit_50')):
     """Times to hit an object at various accuracies
 
     Parameters
     ----------
-    perfect : int
+    hit_300 : int
         The maxumium number of milliseconds away from exactly on time a hit
         can be to still be a 300
-    good : int
+    hit_100 : int
         The maxumium number of milliseconds away from exactly on time a hit
         can be to still be a 100
-    bad : int
+    hit_50 : int
         The maxumium number of milliseconds away from exactly on time a hit
         can be to still be a 50
 
@@ -183,3 +183,19 @@ def od_to_ms(od):
         accuracies.
     """
     return HitWindows((159 - 12 * od) / 2, (279 - 16 * od) / 2, (399 - 20 * od) / 2)
+
+def od_to_ms_300(od):
+    """Convert an overall difficulty value into milliseconds to hit an object at
+    maximum accuracy.
+
+    Parameters
+    ----------
+    od : float
+        The overall difficulty.
+
+    Returns
+    -------
+    ms : float
+        The number of milliseconds to hit an object at maximum accuracy.
+    """
+    return 79.5 - 6 * od

--- a/slider/mod.py
+++ b/slider/mod.py
@@ -147,9 +147,29 @@ def circle_radius(cs):
     return (512 / 16) * (1 - 0.7 * (cs - 5) / 5)
 
 
+class HitWindows(namedtuple('HitWindows', 'perfect, good, bad')):
+    """Times to hit an object at various accuracies
+
+    Parameters
+    ----------
+    perfect : int
+        The maxumium number of milliseconds away from exactly on time a hit
+        can be to still be a 300
+    good : int
+        The maxumium number of milliseconds away from exactly on time a hit
+        can be to still be a 100
+    bad : int
+        The maxumium number of milliseconds away from exactly on time a hit
+        can be to still be a 50
+
+    Notes
+    -----
+    A hit further than the ``bad`` value away from exactly on time is a miss.
+    """
+
 def od_to_ms(od):
     """Convert an overall difficulty value into milliseconds to hit an object at
-    maximum accuracy.
+    various accuracies.
 
     Parameters
     ----------
@@ -158,7 +178,8 @@ def od_to_ms(od):
 
     Returns
     -------
-    ms : float
-        The number of milliseconds to hit an object at maximum accuracy.
+    hw : HitWindows
+        A namedtuple of numbers of milliseconds to hit an object at different
+        accuracies.
     """
-    return 79.5 - 6 * od
+    return HitWindows((159 - 12 * od) / 2, (279 - 16 * od) / 2, (399 - 20 * od) / 2)


### PR DESCRIPTION
I'm not sure I did the docs right (I'm not that familiar with reStructuredText)

I think that perhaps there should also be some way to process mods during these calculations.  
For example, the hitwindows will need to be multiplied by 2/3 for use with DT. Not sure how best to implement this if we even should.

As a note:  
The calculations for these ODs are based on some forum posts by random people I found a while back adjusted to fit all of the values on [this](https://w.ppy.sh/8/88/ODTable.png) chart (a larger version of the one on the wiki). The 300 one matches up with what you had before (all multiplied by 2).  
This is because all I can find in the [osu source](https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs#L45) is this:

```C#
public double HitWindowFor(OsuScoreResult result)
    {
        switch (result)
        {
        default:
            return 300;
        case OsuScoreResult.Hit50:
            return 150;
        case OsuScoreResult.Hit100:
            return 80;
        case OsuScoreResult.Hit300:
            return 30;
       }
   }
```
Which doesn't seem to actually be doing any calculations. Either they override / modify these values somehow elsewhere which I haven't found, or they haven't sorted it out on lazer yet.