### PR TITLE
Method to retrieve difficulties of each hit object in a beatmap

### DIFF
--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1852,7 +1852,7 @@ class Beatmap:
                               hard_rock=False,
                               double_time=False,
                               half_time=False,
-                              inc_times=False):
+                              include_times=False):
         """Compute the difficulty of each hit object.
 
         Parameters
@@ -1867,17 +1867,18 @@ class Beatmap:
             Compute difficulty with double time.
         half_time : bool
             Compute difficulty with half time.
-        inc_times : bool
+        include_times : bool
             Whether to include the times of the hit objects.
 
         Returns
         ----------
         difficulties : array
             1D array of difficulties.
-            If inc_times is True, the array is 2D
+            If include_times is True, the array is 2D
             and contains time, difficulty pairs.
         """
         cs = self.cs()
+        # NOTE: This is different than normal conversion
         if hard_rock:
             cs *= 1.3
         elif easy:
@@ -1892,7 +1893,7 @@ class Beatmap:
             def modify(e):
                 return e
 
-        if inc_times:
+        if include_times:
             strains = np.empty((len(self.hit_objects) - 1, 2))
         else:
             strains = np.empty(len(self.hit_objects) - 1)
@@ -1905,7 +1906,7 @@ class Beatmap:
                 radius,
                 previous,
             )
-            if inc_times:
+            if include_times:
                 strains[i] = hit_object.time.total_seconds(), new.strains[strain]
             else:
                 strains[i] = new.strains[strain]
@@ -1960,7 +1961,7 @@ class Beatmap:
                 hard_rock=hard_rock,
                 double_time=double_time,
                 half_time=half_time,
-                inc_times=True,
+                include_times=True,
             ),
             smoothing_window,
             num_points,

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -959,14 +959,6 @@ def _moving_average_by_time(times, data, delta, num):
     return out_times.reshape((-1, 1)), out_values
 
 
-@unique
-class Strain(IntEnum):
-    """Indices for the strain specific values.
-    """
-    speed = 0
-    aim = 1
-
-
 class _DifficultyHitObject:
     """An object used to accumulate the strain information for calculating
     stars.
@@ -991,6 +983,13 @@ class _DifficultyHitObject:
 
     circle_size_buffer_threshold = 30
 
+    @unique
+    class Strain(IntEnum):
+        """Indices for the strain specific values.
+        """
+        speed = 0
+        aim = 1
+
     def __init__(self, hit_object, radius, previous=None):
         self.hit_object = hit_object
 
@@ -1011,8 +1010,8 @@ class _DifficultyHitObject:
             self.strains = 0, 0
         else:
             self.strains = (
-                self._calculate_strain(previous, Strain.speed),
-                self._calculate_strain(previous, Strain.aim),
+                self._calculate_strain(previous, self.Strain.speed),
+                self._calculate_strain(previous, self.Strain.aim),
             )
 
     def _calculate_strain(self, previous, strain):
@@ -1056,7 +1055,7 @@ class _DifficultyHitObject:
         return np.sqrt((start.x - end.x) ** 2 + (start.y - end.y) ** 2)
 
     def _spacing_weight(self, distance, strain):
-        if strain == Strain.speed:
+        if strain == self.Strain.speed:
             if distance > self.single_spacing:
                 return 2.5
             elif distance > self.stream_spacing:
@@ -2062,11 +2061,11 @@ class Beatmap:
         rhythm_awkwardness *= 82
 
         aim = self._calculate_difficulty(
-            Strain.aim,
+            _DifficultyHitObject.Strain.aim,
             difficulty_hit_objects,
         )
         speed = self._calculate_difficulty(
-            Strain.speed,
+            _DifficultyHitObject.Strain.speed,
             difficulty_hit_objects,
         )
 

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -949,12 +949,12 @@ def _moving_average_by_time(times, data, delta, num):
     values = np.vstack([data, [np.nan] * data.shape[1]])
 
     # sum the values in the ranges ``[window_start_ixs, window_stop_ixs)``
-    window_sums = (np.add.reduceat(i, window_ixs.ravel())[::2] for i in values.transpose())
+    window_sums = np.add.reduceat(values, window_ixs.ravel())[::2]
     window_sizes = np.diff(window_ixs, axis=1).ravel()
     # convert window_sizes of 0 to 1 (inplace) to prevent division by zero
     np.clip(window_sizes, 1, None, out=window_sizes)
 
-    out_values = np.stack([i / window_sizes for i in window_sums], axis=1)
+    out_values = np.stack(window_sums / window_sizes.reshape((-1, 1)))
 
     return out_times.reshape((-1, 1)), out_values
 

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1816,6 +1816,41 @@ class Beatmap:
 
                 yield sequence[n], sequence[m]
 
+    def hit_object_difficulty(self,
+                              strain,
+                              easy=False,
+                              hard_rock=False,
+                              double_time=False,
+                              half_time=False):
+        cs = self.cs()
+        if hard_rock:
+            cs *= 1.3
+        elif easy:
+            cs /= 2
+        radius = circle_radius(cs)
+
+        if double_time:
+            modify = op.attrgetter('double_time')
+        elif half_time:
+            modify = op.attrgetter('half_time')
+        else:
+            def modify(e):
+                return e
+
+        strains = np.empty(len(self.hit_objects) - 1)
+
+        hit_objects = map(modify, self.hit_objects)
+        previous = _DifficultyHitObject(next(hit_objects), radius)
+        for i, hit_object in enumerate(hit_objects):
+            new = _DifficultyHitObject(
+                hit_object,
+                radius,
+                previous,
+            )
+            strains[i] = new.strains[strain]
+            previous = new
+        return strains
+
     def _calculate_stars(self,
                          easy,
                          hard_rock,


### PR DESCRIPTION
I've moved the Strain enum out of the _DifficultyHitObject so users can use it to specify the strain they want to retrieve.

I also added a smooth difficulty that does a moving average on the difficulties to smooth it into something representative of the difficulty of the section.

There's some code duplicated from _calculate_stars (cs adjustment etc.) but I couldn't think of a way to merge it. 