### PR TITLE
fix client issues and error message

### DIFF
--- a/slider/client.py
+++ b/slider/client.py
@@ -599,7 +599,7 @@ class Client:
 
         parameters = {
             'k': self.api_key,
-            'a': include_converted_beatmaps,
+            'a': int(bool(include_converted_beatmaps)),
             'limit': limit,
         }
 

--- a/slider/client.py
+++ b/slider/client.py
@@ -436,7 +436,7 @@ class UnknownBeatmap(LookupError):
     """
     def __init__(self, kind, id_):
         self.kind = kind
-        self.id_ = id
+        self.id_ = id_
 
     def __str__(self):
         return f'no beatmap found that matched {self.kind}: {self.id_}'
@@ -651,7 +651,7 @@ class Client:
                     id_ = beatmap_id
                 else:
                     kind = 'md5'
-                    id_ = beatmap_id
+                    id_ = beatmap_md5
 
                 raise UnknownBeatmap(kind, id_)
 

--- a/slider/library.py
+++ b/slider/library.py
@@ -222,7 +222,7 @@ class Library:
 
         Parameters
         ----------
-        beatmap_id : int
+        beatmap_id : int or str
             The id of the beatmap to lookup.
 
         Returns
@@ -343,7 +343,7 @@ class Library:
 
         Parameters
         ----------
-        beatmap_id : int
+        beatmap_id : int or str
             The id of the beatmap to download.
         save : bool, optional
             Save the beatmap to disk?
@@ -366,12 +366,16 @@ class Library:
 
     @property
     def md5s(self):
+        """All of the beatmap hashes that this has downloaded.
+        """
         return tuple(
             key[4:] for key in self._cache.keys() if key.startswith(b'md5:')
         )
 
     @property
     def ids(self):
+        """All of the beatmap ids that this has downloaded.
+        """
         return tuple(
             int(key[3:])
             for key in self._cache.keys()


### PR DESCRIPTION
Fix for #14

There were 3 problems here:

1. The error message was broken and didn't report the unknown beatmap identifer
2. If beatmaps were looked up by hash, the error message would report the beatmap id which was None
3. The osu! api wants an integer for `include_converted_beatmaps`, not a boolean.

@de-odex can you review this an make sure it fixes your problem?