### PR TITLE
Round num_beats

### DIFF
--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -673,7 +673,7 @@ class Slider(HitObject):
             ms_per_beat = tp.ms_per_beat
 
         pixels_per_beat = slider_multiplier * 100 * velocity_multiplier
-        num_beats = (pixel_length * repeat) / pixels_per_beat
+        num_beats = np.round(((pixel_length * repeat) / pixels_per_beat) * 16) / 16
         duration = timedelta(milliseconds=np.ceil(num_beats * ms_per_beat))
 
         ticks = int(


### PR DESCRIPTION
While it's possible to have notes that aren't on multiples of 1/16 of a beats, as far as I can tell it's impossible to have sliders with lengths that aren't 1/16 beat multiples in the editor. I'm going to assume that means it's also impossible in general in the game so num_beats should round to the nearest 1/16. At the moment 1 beat sliders often come out with 1.00065 or so beats which causes #24