### PR TITLE
ENH: use sqlite3 as the backing for the library instead of dbm

### DIFF
--- a/docs/source/working-with-beatmaps.rst
+++ b/docs/source/working-with-beatmaps.rst
@@ -30,7 +30,7 @@ Slider libraries can be created from the command line like:
 
 .. code-block:: bash
 
-   $ python -m slider library --beatmaps=/path/to/beatmap/root [--recurse/--no-recurse]
+   $ python -m slider library /path/to/beatmap/root [--recurse/--no-recurse]
 
 This command will search through ``/path/to/beatmap/root`` recursively and store
 metadata to allow slider to quickly find the ``.osu`` files. In the root of the

--- a/slider/__main__.py
+++ b/slider/__main__.py
@@ -10,10 +10,9 @@ def main():
 
 
 @main.command()
-@click.option(
-    '--beatmaps',
-    help='The path to the beatmap directory.',
-    required=True,
+@click.argument(
+    'beatmaps',
+    type=click.Path(exists=True, file_okay=False),
 )
 @click.option(
     '--recurse/--no-recurse',


### PR DESCRIPTION
sqlite3, like dbm is built into the stdlib. Unlike dbm, sqlite3 files are
extremely portable. This means that a library generated on one machine may be
used on any other machine that slider supports. This can dramatically speed up
server deploys by allowing us to build a library once on a CI machine like
jenkins or travis and use that artifact in our deploys.

To assist with making libraries portable, paths are now stored relative to the
'.slider.db' file. This means that the entire library directory could be
relocated without needing to rebuild or adjust any values. The relocatability
allows us to create a tar archive of a library and ship this around to any other
servers regardless of where it will be unpacked.

There should be no API changes for consumers of `Library`; however, you will need to rebuild the library to get a new `.slider.db` sqliite file.

ping @blimmo @de-odex 