### PR TITLE
add Library#beatmap_from_file method

### DIFF
--- a/slider/library.py
+++ b/slider/library.py
@@ -294,11 +294,12 @@ class Library:
         beatmap : Beatmap
             The beatmap represented by the given file.
         """
-        beatmap = Beatmap.from_path(path)
+        data_bytes = open(path, 'rb').read()
+        data = data_bytes.decode('utf-8-sig')
+        beatmap = Beatmap.parse(data)
 
         if copy:
-            data = open(path, 'rb').read()
-            self.save(data, beatmap=beatmap)
+            self.save(data_bytes, beatmap=beatmap)
 
         return beatmap
 

--- a/slider/library.py
+++ b/slider/library.py
@@ -279,6 +279,29 @@ class Library:
         """
         return self._read_beatmap(self, beatmap_md5=beatmap_md5)
 
+    def beatmap_from_file(self, path, copy=False):
+        """Returns a beatmap from a file on disk.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            The path to the file to create the beatmap from.
+        copy : bool
+            Should the file be copied to the library's beatmap directory?
+
+        Returns
+        -------
+        beatmap : Beatmap
+            The beatmap represented by the given file.
+        """
+        beatmap = Beatmap.from_path(path)
+
+        if copy:
+            data = open(path, 'rb').read()
+            self.save(data, beatmap=beatmap)
+
+        return beatmap
+
     def save(self, data, *, beatmap=None):
         """Save raw data for a beatmap at a given location.
 

--- a/slider/library.py
+++ b/slider/library.py
@@ -279,7 +279,7 @@ class Library:
         """
         return self._read_beatmap(self, beatmap_md5=beatmap_md5)
 
-    def beatmap_from_file(self, path, copy=False):
+    def beatmap_from_path(self, path, copy=False):
         """Returns a beatmap from a file on disk.
 
         Parameters


### PR DESCRIPTION
This method allows the loading of a beatmap from a file, and optionally copying it to the library's backing directory.

I realize this is half duplicating the logic that already exists in `Beatmap.from_path`, but I've been treating `Library` as the main entry point to slider. `Beatmap` could also have had a `from_id` option (as opposed to library's `lookup_by_id(download=True)`), but this was put/consolidated in `Library` instead, so I don't think I'm entirely off base here.