### PR TITLE
add support for catmull sliders

### DIFF
--- a/slider/curve.py
+++ b/slider/curve.py
@@ -318,18 +318,18 @@ class Catmull(Curve):
         # we interpolate twice, first on the x axis then on the y axis
         p1 = points[0].x
         p2 = points[1].x
-        t1 = 0.5 * (p1 - p2)
-        t2 = 0.5 * (p2 - p1)
-        self.C1 = np.array([p1, p2, t1, t2])
+        t1 = 0.5 * (p2 - p1)
+        t2 = 0.5 * (p1 - p2)
+        self.Cx = np.array([p1, p2, t1, t2])
         # make it a column vector
-        self.C1 = self.C1[:, np.newaxis]
+        self.Cx = self.Cx[:, np.newaxis]
 
         p1 = points[0].y
         p2 = points[1].y
-        t1 = 0.5 * (p1 - p2)
-        t2 = 0.5 * (p2 - p1)
-        self.C2 = np.array([p1, p2, t1, t2])
-        self.C2 = self.C2[:, np.newaxis]
+        t1 = 0.5 * (p2 - p1)
+        t2 = 0.5 * (p1 - p2)
+        self.Cy = np.array([p1, p2, t1, t2])
+        self.Cy = self.Cy[:, np.newaxis]
 
     def __call__(self, t):
         # for consistency with notes linked above
@@ -338,8 +338,8 @@ class Catmull(Curve):
                       s ** 2,
                       s,
                       1])
-        px = (S @ self.h) @ self.C1
-        py = (S @ self.h) @ self.C2
+        px = (S @ self.h) @ self.Cx
+        py = (S @ self.h) @ self.Cy
         # A bit of dimensional analysis:
         # S = 1x4
         # C = 4x1

--- a/slider/curve.py
+++ b/slider/curve.py
@@ -312,10 +312,10 @@ class Catmull(Curve):
         points = np.array(points)
 
         # implementation follows notes at https://cubic.org/docs/hermite.htm
-        self.h = np.array([[ 2, -2,  1,  1],
+        self.h = np.array([[2,  -2,  1,  1],
                            [-3,  3, -2, -1],
-                           [ 0,  0,  1,  0],
-                           [ 1,  0,  0,  0]])
+                           [0,   0,  1,  0],
+                           [1,   0,  0,  0]])
 
         tangents_x = []
         tangents_y = []
@@ -342,7 +342,6 @@ class Catmull(Curve):
         p_behinds = np.roll(points, -1)
         p_behinds[-1] = p_behinds[-2]
 
-
         # we interpolate x and y separately, so track their tangents in two
         # separate lists.
         for (p_ahead, p_behind) in zip(p_aheads, p_behinds):
@@ -351,7 +350,6 @@ class Catmull(Curve):
 
             tangent = 0.5 * (p_ahead[1] - p_behind[1])
             tangents_y.append(tangent)
-
 
         # for each curve we consider its start and end point (and start and end
         # tangent). This means the number of curves will be one less than the
@@ -370,7 +368,6 @@ class Catmull(Curve):
             Cy = Cy[:, np.newaxis]
             self.Cys.append(Cy)
 
-
     def __call__(self, t):
         # for consistency with notes linked above
         s = t
@@ -378,8 +375,8 @@ class Catmull(Curve):
         # catmull curves are made up of a number of individual curves. Assuming
         # osu! weights each curve equally (that is, each curve takes an equal
         # amount of time to traverse regardless of its size), we can get the
-        # curve that should be used for a certain t by multiplying by the number
-        # of curves and rounding up.
+        # curve that should be used for a certain t by multiplying by the
+        # number of curves and rounding up.
         curve_index = math.ceil(t * len(self.Cxs)) - 1
         Cx = self.Cxs[curve_index]
         Cy = self.Cys[curve_index]

--- a/slider/curve.py
+++ b/slider/curve.py
@@ -319,7 +319,7 @@ class Catmull(Curve):
         p1 = points[0].x
         p2 = points[1].x
         t1 = 0.5 * (p2 - p1)
-        t2 = 0.5 * (p1 - p2)
+        t2 = 0.5 * (p2 - p1)
         self.Cx = np.array([p1, p2, t1, t2])
         # make it a column vector
         self.Cx = self.Cx[:, np.newaxis]
@@ -327,7 +327,7 @@ class Catmull(Curve):
         p1 = points[0].y
         p2 = points[1].y
         t1 = 0.5 * (p2 - p1)
-        t2 = 0.5 * (p1 - p2)
+        t2 = 0.5 * (p2 - p1)
         self.Cy = np.array([p1, p2, t1, t2])
         self.Cy = self.Cy[:, np.newaxis]
 


### PR DESCRIPTION
closes #20

I'm not 100% on the correctness of this implementation, but at the very least it isn't totally wrong, and that's better than the 0 support we have right now.

The script I used for testing (requires circleguard and circlevis):
```python
from circleguard import *
from circlevis import *

cg = Circleguard("key")
# uncomment one of the below to use that one for testing
# r = ReplayPath("/Users/tybug/Desktop/catmull-jxu.osr") # at t 1478 and 6812, 2 control points each
r = ReplayPath("/Users/tybug/Desktop/catmull-www.osr") # at t 42000, 12 control points
cg.load(r)

bm = BeatmapInfo(map_id=r.map_id)
vis = VisualizerApp(bm, [r])
vis.exec()
```

And here are the two replays in question: [catmull replays.zip](https://github.com/llllllllll/slider/files/5360489/catmull.replays.zip)


![image](https://user-images.githubusercontent.com/31628143/95668553-95ddfd80-0b43-11eb-9de6-8d252a98ff70.png)
