### PR TITLE
fix tz offset in api requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     install_requires=[
         'click',
         'numpy',
-        'pytz',
         'requests',
         'scipy',
         'toolz',

--- a/slider/client.py
+++ b/slider/client.py
@@ -1,7 +1,6 @@
 import datetime
 from enum import IntEnum, unique
 
-import pytz
 import requests
 
 from .game_mode import GameMode
@@ -523,14 +522,8 @@ class Client:
         'passcount': 'pass_count',
     }
 
-    def _parse_date(cs, *, _tz=pytz.FixedOffset(8 * 60)):
-        # _tz is UTC+8
-        if cs is None:
-            return None
-
-        return _tz.localize(
-            datetime.datetime.strptime(cs, '%Y-%m-%f %H:%M:%S'),
-        )
+    def _parse_date(cs):
+        return datetime.datetime.strptime(cs, '%Y-%m-%f %H:%M:%S')
 
     def _parse_timedelta(cs):
         return datetime.timedelta(seconds=int(cs))


### PR DESCRIPTION
as of september 2018, the api was changed to return dates in utc+0 instead of the previous utc+8: https://github.com/ppy/osu-api/issues/224#issuecomment-425086858.

This pr also removes pytz as a dependency.