### PR TITLE
remove toolz as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'pytz',
         'requests',
         'scipy',
-        'toolz',
     ],
     extras_require={
         'dev': [

--- a/slider/curve.py
+++ b/slider/curve.py
@@ -7,7 +7,6 @@ try:  # SciPy >= 0.19
     from scipy.special import comb
 except ImportError:
     from scipy.misc import comb
-from toolz import sliding_window
 
 from .abc import ABCMeta, abstractmethod
 from .position import Position
@@ -221,7 +220,7 @@ class MultiBezier(_MetaCurveMixin, Curve):
             The groups split on duplicates.
         """
         old_ix = 0
-        for n, (a, b) in enumerate(sliding_window(2, input_), 1):
+        for n, (a, b) in enumerate(zip(input_, input_[1:]), 1):
             if a == b:
                 yield input_[old_ix:n]
                 old_ix = n
@@ -245,7 +244,7 @@ class Linear(_MetaCurveMixin, Curve):
         super().__init__(points, req_length)
 
         self._curves = [
-            Bezier(subpoints, None) for subpoints in sliding_window(2, points)
+            Bezier(subpoints, None) for subpoints in zip(points, points[1:])
         ]
 
 


### PR DESCRIPTION
personally I don't think we should have a dependency (even a light one) for only one or two use cases we can replace ourselves, but will leave that decision up to you @llllllllll. 

To convince yourself the functionality is the same:

```python
from toolz import sliding_window
import random

maxint = 10000

for _ in range(500):
    rand_list = [random.randint(0, maxint) for _ in range(100)]
    assert list(sliding_window(2, rand_list)) == list(zip(rand_list, rand_list[1:]))
```