### PR TITLE
fix beatmap parsing failing on beatmaps with whitespace on empty lines

### DIFF
--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1844,8 +1844,10 @@ class Beatmap:
             group_buffer = []
 
         for line in lines:
-            if not line or line.startswith('//'):
-                # filter out empty lines and comments
+            if not line.strip() or line.startswith('//'):
+                # filter out empty lines and comments. Call `strip` because
+                # some (presmuably manually edited) beatmaps have whitespace on
+                # otherwise empty lines. We want to treat these as empty lines.
                 continue
 
             if line[0] == '[' and line[-1] == ']':

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1849,7 +1849,7 @@ class Beatmap:
             # occurring at specific indices to fail, so we get rid of it.
             line = line.strip()
             if not line or line.startswith('//'):
-                # filter out empty lines and comments.
+                # filter out empty lines and comments
                 continue
 
             if line[0] == '[' and line[-1] == ']':

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1844,10 +1844,12 @@ class Beatmap:
             group_buffer = []
 
         for line in lines:
-            if not line.strip() or line.startswith('//'):
-                # filter out empty lines and comments. Call `strip` because
-                # some (presmuably manually edited) beatmaps have whitespace on
-                # otherwise empty lines. We want to treat these as empty lines.
+            # some (presmuably manually edited) beatmaps have whitespace at the
+            # beginning or end of lines. This can cause logic relying on tokens
+            # occurring at specific indices to fail, so we get rid of it.
+            line = line.strip()
+            if not line or line.startswith('//'):
+                # filter out empty lines and comments.
                 continue
 
             if line[0] == '[' and line[-1] == ']':


### PR DESCRIPTION
Some (presumably manually edited) beatmaps have whitespace on otherwise empty lines, which was causing slider to treat the whitespace as the line value. Closes https://github.com/llllllllll/slider/issues/71