### PR TITLE
add a method to get the closest hitobject to a time

### DIFF
--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1232,9 +1232,6 @@ class Beatmap:
         self.slider_tick_rate = slider_tick_rate
         self.timing_points = timing_points
         self._hit_objects = hit_objects
-        # a (sorted) list of hitobject time's, so they can be searched with
-        # ``np.searchsorted``
-        self._hit_object_times = []
         # cache hit object stacking at different ar and cs values
         self._hit_objects_with_stacking = {}
 
@@ -1683,6 +1680,14 @@ class Beatmap:
 
         return hit_objects
 
+    @lazyval
+    def _hit_object_times(self):
+        """a (sorted) list of hitobject time's, so they can be searched with
+        ``np.searchsorted``
+        """
+        return [hitobj.time for hitobj in self._hit_objects]
+
+
     def closest_hitobject(self, t, side="left"):
         """The hitobject closest in time to ``t``.
 
@@ -1703,9 +1708,6 @@ class Beatmap:
         if len(self._hit_objects) <= 1:
             return self._hit_objects[0] if self._hit_objects else None
 
-        if not self._hit_object_times:
-            self._hit_object_times = [hitobj.time for hitobj
-                                      in self._hit_objects]
         i = np.searchsorted(self._hit_object_times, t)
         # if ``t`` is after the last hitobject, an index of
         # len(self._hit_objects) will be returned. The last hitobject will

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1687,7 +1687,6 @@ class Beatmap:
         """
         return [hitobj.time for hitobj in self._hit_objects]
 
-
     def closest_hitobject(self, t, side="left"):
         """The hitobject closest in time to ``t``.
 

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1704,8 +1704,8 @@ class Beatmap:
             return self._hit_objects[0] if self._hit_objects else None
 
         if not self._hit_object_times:
-            self._hit_object_times = [hitobj.time.total_seconds() * 1000
-                                      for hitobj in self._hit_objects]
+            self._hit_object_times = [hitobj.time for hitobj
+                                      in self._hit_objects]
         i = np.searchsorted(self._hit_object_times, t)
         # if ``t`` is after the last hitobject, an index of
         # len(self._hit_objects) will be returned. The last hitobject will
@@ -1720,8 +1720,8 @@ class Beatmap:
         # closer. Check both candidates.
         hitobj1 = self._hit_objects[i - 1]
         hitobj2 = self._hit_objects[i]
-        dist1 = abs(hitobj1.time.total_seconds() * 1000 - t)
-        dist2 = abs(hitobj2.time.total_seconds() * 1000 - t)
+        dist1 = abs(hitobj1.time - t)
+        dist2 = abs(hitobj2.time - t)
 
         hitobj1_closer = dist1 <= dist2 if side == "left" else dist1 < dist1
 

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1683,18 +1683,21 @@ class Beatmap:
 
         return hit_objects
 
-    def closest_hitobject(self, t):
+    def closest_hitobject(self, t, side="left"):
         """The hitobject closest in time to ``t``.
 
         Parameters
         ----------
         t : :class:`datetime.timedelta`
-            The time to find the hitobject closes to.
+            The time to find the hitobject closest to.
 
         Returns
         -------
         hit_object : :class:`~.HitObject`
             The closest hitobject in time to ``t``.
+        side : {"left", "right"}
+            Whether to prefer the earlier (left) or later (right) hitobject
+            when breaking ties.
         """
         if not self._hit_object_times:
             self._hit_object_times = [hitobj.time.total_seconds() * 1000
@@ -1713,8 +1716,12 @@ class Beatmap:
         # closer. Check both candidates.
         hitobj1 = self._hit_objects[i - 1]
         hitobj2 = self._hit_objects[i]
-        if abs(hitobj1.time.total_seconds() * 1000 - t) < \
-           abs(hitobj2.time.total_seconds() * 1000 - t):
+        dist1 = abs(hitobj1.time.total_seconds() * 1000 - t)
+        dist2 = abs(hitobj2.time.total_seconds() * 1000 - t)
+
+        hitobj1_closer = dist1 <= dist2 if side == "left" else dist1 < dist1
+
+        if hitobj1_closer:
             return hitobj1
         return hitobj2
 

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1692,7 +1692,7 @@ class Beatmap:
 
         Parameters
         ----------
-        t : :class:`datetime.timedelta`
+        t : datetime.timedelta
             The time to find the hitobject closest to.
         side : {"left", "right"}
             Whether to prefer the earlier (left) or later (right) hitobject
@@ -1700,7 +1700,7 @@ class Beatmap:
 
         Returns
         -------
-        hit_object : :class:`~.HitObject`
+        hit_object : HitObject
             The closest hitobject in time to ``t``.
         None
             If the beatmap has no hitobjects.

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1694,14 +1694,16 @@ class Beatmap:
         ----------
         t : :class:`datetime.timedelta`
             The time to find the hitobject closest to.
+        side : {"left", "right"}
+            Whether to prefer the earlier (left) or later (right) hitobject
+            when breaking ties.
 
         Returns
         -------
         hit_object : :class:`~.HitObject`
             The closest hitobject in time to ``t``.
-        side : {"left", "right"}
-            Whether to prefer the earlier (left) or later (right) hitobject
-            when breaking ties.
+        None
+            If the beatmap has no hitobjects.
         """
         # if the beatmap only has one object, return that, else return None
         if len(self._hit_objects) <= 1:

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1688,7 +1688,7 @@ class Beatmap:
         """
         if not self._hit_object_times:
             self._hit_object_times = [hitobj.time.total_seconds() * 1000
-                for hitobj in self._hit_objects]
+                                      for hitobj in self._hit_objects]
         i = np.searchsorted(self._hit_object_times, t)
         # if ``t`` is after the last hitobject, an index of
         # len(self._hit_objects) will be returned. The last hitobject will
@@ -1704,7 +1704,7 @@ class Beatmap:
         hitobj1 = self._hit_objects[i - 1]
         hitobj2 = self._hit_objects[i]
         if abs(hitobj1.time.total_seconds() * 1000 - t) < \
-            abs(hitobj2.time.total_seconds() * 1000 - t):
+           abs(hitobj2.time.total_seconds() * 1000 - t):
             return hitobj1
         return hitobj2
 

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1699,6 +1699,10 @@ class Beatmap:
             Whether to prefer the earlier (left) or later (right) hitobject
             when breaking ties.
         """
+        # if the beatmap only has one object, return that, else return None
+        if len(self._hit_objects) <= 1:
+            return self._hit_objects[0] if self._hit_objects else None
+
         if not self._hit_object_times:
             self._hit_object_times = [hitobj.time.total_seconds() * 1000
                                       for hitobj in self._hit_objects]

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1684,7 +1684,17 @@ class Beatmap:
         return hit_objects
 
     def closest_hitobject(self, t):
-        """The hitobject with a ``time`` closest to ``t`` (in ms).
+        """The hitobject closest in time to ``t``.
+
+        Parameters
+        ----------
+        t : :class:`datetime.timedelta`
+            The time to find the hitobject closes to.
+
+        Returns
+        -------
+        hit_object : :class:`~.HitObject`
+            The closest hitobject in time to ``t``.
         """
         if not self._hit_object_times:
             self._hit_object_times = [hitobj.time.total_seconds() * 1000

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1705,9 +1705,11 @@ class Beatmap:
         None
             If the beatmap has no hitobjects.
         """
-        # if the beatmap only has one object, return that, else return None
-        if len(self._hit_objects) <= 1:
-            return self._hit_objects[0] if self._hit_objects else None
+        if len(self._hit_objects) == 0:
+            raise ValueError(f"The beatmap {self!r} must have at least one "
+                              "hit object to determine the closest hitobject.")
+        if len(self._hit_objects) == 1:
+            return self._hit_objects[0]
 
         i = np.searchsorted(self._hit_object_times, t)
         # if ``t`` is after the last hitobject, an index of

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1707,7 +1707,7 @@ class Beatmap:
         """
         if len(self._hit_objects) == 0:
             raise ValueError(f"The beatmap {self!r} must have at least one "
-                              "hit object to determine the closest hitobject.")
+                             "hit object to determine the closest hitobject.")
         if len(self._hit_objects) == 1:
             return self._hit_objects[0]
 

--- a/slider/tests/test_beatmap.py
+++ b/slider/tests/test_beatmap.py
@@ -186,6 +186,26 @@ def test_hit_objects_hard_rock(beatmap):
                                                     Position(x=301, y=209)]
 
 
+def test_closest_hitobject():
+    beatmap = slider.example_data.beatmaps.miiro_vs_ai_no_scenario('Beginner')
+    hit_object1 = beatmap.hit_objects()[4]
+    hit_object2 = beatmap.hit_objects()[5]
+    hit_object3 = beatmap.hit_objects()[6]
+
+    middle_t = timedelta(milliseconds=11076 - ((11076 - 9692) / 2))
+
+    assert hit_object1.time == timedelta(milliseconds=8615)
+    assert hit_object2.time == timedelta(milliseconds=9692)
+    assert hit_object3.time == timedelta(milliseconds=11076)
+
+    assert beatmap.closest_hitobject(timedelta(milliseconds=8615)) == \
+        hit_object1
+    assert beatmap.closest_hitobject(timedelta(milliseconds=(8615 - 30))) == \
+        hit_object1
+    assert beatmap.closest_hitobject(middle_t) == hit_object2
+    assert beatmap.closest_hitobject(middle_t, side="right") == hit_object3
+
+
 def test_ar(beatmap):
     assert beatmap.ar() == 9.5
 


### PR DESCRIPTION
seems like a convenient method to have access to. The hitobject start times are cached as an attribute upon first use (necessary for use in `np.searchsorted`).