### PR TITLE
add __repr__ for `Action`

### DIFF
--- a/slider/replay.py
+++ b/slider/replay.py
@@ -70,8 +70,8 @@ class Action:
             actions.append("M1")
         if self.mouse2:
             actions.append("M2")
-        return (f"{int(self.offset.total_seconds() * 1000)}ms, {self.position}"
-            f", {' + '.join(actions) or 'No Keypresses'}")
+        return (f"{self.offset}, {self.position}, "
+                f"{' + '.join(actions) or 'No Keypresses'}")
 
 
 def _consume_life_bar_graph(buffer):

--- a/slider/replay.py
+++ b/slider/replay.py
@@ -73,6 +73,7 @@ class Action:
         return (f"<{type(self).__qualname__}: {self.offset}, {self.position}, "
                 f"{' + '.join(actions) or 'No Keypresses'}>")
 
+
 def _consume_life_bar_graph(buffer):
     life_bar_graph_raw = consume_string(buffer)
     return [

--- a/slider/replay.py
+++ b/slider/replay.py
@@ -60,6 +60,19 @@ class Action:
             k2=self.key2,
         )
 
+    def __str__(self):
+        actions = []
+        if self.key1:
+            actions.append("K1")
+        if self.key2:
+            actions.append("K2")
+        if self.mouse1:
+            actions.append("M1")
+        if self.mouse2:
+            actions.append("M2")
+        return (f"{int(self.offset.total_seconds() * 1000)}ms, {self.position}"
+            f", {' + '.join(actions) or 'No Keypresses'}")
+
 
 def _consume_life_bar_graph(buffer):
     life_bar_graph_raw = consume_string(buffer)

--- a/slider/replay.py
+++ b/slider/replay.py
@@ -60,7 +60,7 @@ class Action:
             k2=self.key2,
         )
 
-    def __str__(self):
+    def __repr__(self):
         actions = []
         if self.key1:
             actions.append("K1")
@@ -70,9 +70,8 @@ class Action:
             actions.append("M1")
         if self.mouse2:
             actions.append("M2")
-        return (f"{self.offset}, {self.position}, "
-                f"{' + '.join(actions) or 'No Keypresses'}")
-
+        return (f"<{type(self).__qualname__}: {self.offset}, {self.position}, "
+                f"{' + '.join(actions) or 'No Keypresses'}>")
 
 def _consume_life_bar_graph(buffer):
     life_bar_graph_raw = consume_string(buffer)


### PR DESCRIPTION
wrote this while looking into #85. I'm not too confident on the style of this string to be honest, especially the keypresses (what to show when there's no keypresses?). Happy to change to something better if asked.

Looks like this:

```
0:06:22.450000, Position(x=213.7778, y=192.4444), No Keypresses
0:06:22.465000, Position(x=213.7778, y=193.3333), K2 + M2
0:06:22.469000, Position(x=213.7778, y=193.3333), K2 + M2
0:06:22.486000, Position(x=214.6667, y=194.2222), K2 + M2
0:06:22.500000, Position(x=216.8889, y=195.5556), K2 + M2
0:06:22.519000, Position(x=219.1111, y=196.8889), K2 + M2
0:06:22.524000, Position(x=222.6667, y=199.1111), No Keypresses
0:06:22.534000, Position(x=228.0, y=202.2222), No Keypresses
0:06:22.550000, Position(x=236.0, y=206.2222), No Keypresses
0:06:22.568000, Position(x=251.5556, y=215.5556), No Keypresses
0:06:22.585000, Position(x=263.1111, y=222.2222), No Keypresses
```