### PR TITLE
fix parsing failing on maps with float x and y positions

### DIFF
--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -348,12 +348,12 @@ class HitObject:
 
         try:
             # in old beatmaps (and potentially newer ones which were manually
-            # edited?), x and y can be floats (see b/128). Without the secondary
-            # float cast, parsing these maps would fail.
+            # edited?), x and y can be floats (see b/128). Without the
+            # secondary float cast, parsing these maps would fail.
             # Lazer casts these to integers
-            # (https://github.com/ppy/osu/blob/d4ea57c6607a77abb8a5e2fe55b220d8d
-            # feeb456/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
-            # #L49), so we're still matching in-game positions even though we
+            # (https://github.com/ppy/osu/blob/d4ea57c6607a77abb8a5e2fe55b220d8
+            # dfeeb456/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.
+            # cs#L49), so we're still matching in-game positions even though we
             # technically lose precision from the .osu file by casting.
             x = int(float(x))
         except ValueError:

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -347,12 +347,20 @@ class HitObject:
             raise ValueError(f'not enough elements in line, got {data!r}')
 
         try:
-            x = int(x)
+            # in old beatmaps (and potentially newer ones which were manually
+            # edited?), x and y can be floats (see b/128). Without the secondary
+            # float cast, parsing these maps would fail.
+            # Lazer casts these to integers
+            # (https://github.com/ppy/osu/blob/d4ea57c6607a77abb8a5e2fe55b220d8d
+            # feeb456/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+            # #L49), so we're still matching in-game positions even though we
+            # technically lose precision from the .osu file by casting.
+            x = int(float(x))
         except ValueError:
             raise ValueError(f'x should be an int, got {x!r}')
 
         try:
-            y = int(y)
+            y = int(float(y))
         except ValueError:
             raise ValueError(f'y should be an int, got {y!r}')
 


### PR DESCRIPTION
closes https://github.com/circleguard/circleguard/issues/179. See inline comment for details, and `library.lookup_by_id(128, download=True, save=True)` for a repro case