### PR TITLE
enables Beatmaps to be written back to .osu files

### DIFF
--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1318,17 +1318,18 @@ def _pack_str_list(field: str, list_str: list, default=no_default):
     return ' '.join(list_str)
 
 
-def _pack_int_list(field: str, list_int: list, default=no_default):
-    """Pack a list of int to a string, with space as separator between elements.
+def _pack_timedelta_list(field: str, list_td: list, default=no_default):
+    """Pack a list of timedelta to a string, with space as separator
+    between elements.
 
     Parameters
     ----------
     field : str
         The name  of the field to be packed.
-    list_int : list
+    list_td : list
         The value to be packed to string.
     default : list, optional
-        A value to return if ``list_int`` is not valid.
+        A value to return if ``list_td`` is not valid.
 
     Returns
     -------
@@ -1338,11 +1339,11 @@ def _pack_int_list(field: str, list_int: list, default=no_default):
     Raises
     ------
     ValueError
-        Raised when ``list_int`` is not a list of int
+        Raised when ``list_td`` is not a list of timedelta
         and default is not available.
     """
-    list_int = _invalid_to_default(field, list_int, list, default)
-    return ' '.join((str(int_) for int_ in list_int))
+    list_td = _invalid_to_default(field, list_td, list, default)
+    return ','.join((str(td // timedelta(milliseconds=1)) for td in list_td))
 
 
 def _moving_average_by_time(times, data, delta, num):
@@ -2616,17 +2617,10 @@ class Beatmap:
 
         # pack Editor section
         packed_str += '[Editor]\n'
-
-        def _pack_bookmarks(_field, bookmarks, _default=no_default):
-            bookmarks = [
-                str(b // timedelta(milliseconds=1)) for b in bookmarks
-            ]
-            return ",".join(bookmarks)
-
         # Bookmarks field actually does not even exist in .osu file
         # if there's no bookmark at all.
         packed_str += pack_field('Bookmarks', self.bookmarks,
-                                 _pack_bookmarks, [], skip_empty=True)
+                                 _pack_timedelta_list, [], skip_empty=True)
         packed_str += pack_field('DistanceSpacing', self.distance_spacing,
                                  _pack_float, 1.0)
         packed_str += pack_field('BeatDivisor', self.beat_divisor,

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -2699,7 +2699,7 @@ class Beatmap:
 
         # pack HitObjects section
         packed_str += '[HitObjects]\n'
-        for hit_object in self.hit_objects():
+        for hit_object in self._hit_objects:
             # each hit object occupies a line
             packed_str += hit_object.pack() + '\n'
         packed_str += '\n'

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -2493,7 +2493,7 @@ class Beatmap:
                 timedelta(milliseconds=ms) for ms in _get_as_int_list(
                     groups,
                     'Editor',
-                    'bookmarks',
+                    'Bookmarks',
                     [],
                 )
             ],

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -2586,6 +2586,9 @@ class Beatmap:
                 return ''
             return field + ':' + packed_field_str + '\n'
 
+        # we'll pin ourselves to file format v14 for packing for now. We'll
+        # need to update this if we ever update the format in which we output
+        # packed beatmaps in.
         packed_str = 'osu file format v14\n\n'
 
         # pack General section

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1291,8 +1291,10 @@ def _pack_int_enum(field: str, enum_in: IntEnum, default=no_default):
     return str(int(enum_in))
 
 
-def _pack_str_list(field: str, list_str: list, default=no_default):
-    """Pack a list of string to a string, with space as separator between elements.
+def _pack_str_list(field: str, list_str: list, sep: str = ' ',
+                   default=no_default):
+    """Pack a list of string to a string, with `sep` as separator
+    between elements.
 
     Parameters
     ----------
@@ -1300,6 +1302,8 @@ def _pack_str_list(field: str, list_str: list, default=no_default):
         The name  of the field to be packed.
     list_str : list
         The value to be packed to string.
+    sep : str
+        separator to join packed strings of elements
     default : list, optional
         A value to return if ``list_str`` is not valid.
 
@@ -1315,11 +1319,12 @@ def _pack_str_list(field: str, list_str: list, default=no_default):
         and default is not available.
     """
     list_str = _invalid_to_default(field, list_str, list, default)
-    return ' '.join(list_str)
+    return sep.join(list_str)
 
 
-def _pack_timedelta_list(field: str, list_td: list, default=no_default):
-    """Pack a list of timedelta to a string, with space as separator
+def _pack_timedelta_list(field: str, list_td: list, sep: str = ',',
+                         default=no_default):
+    """Pack a list of timedelta to a string, with `sep` as separator
     between elements.
 
     Parameters
@@ -1328,6 +1333,8 @@ def _pack_timedelta_list(field: str, list_td: list, default=no_default):
         The name  of the field to be packed.
     list_td : list
         The value to be packed to string.
+    sep : str
+        separator to join packed strings of elements
     default : list, optional
         A value to return if ``list_td`` is not valid.
 
@@ -1343,7 +1350,7 @@ def _pack_timedelta_list(field: str, list_td: list, default=no_default):
         and default is not available.
     """
     list_td = _invalid_to_default(field, list_td, list, default)
-    return ','.join((str(td // timedelta(milliseconds=1)) for td in list_td))
+    return sep.join((str(td // timedelta(milliseconds=1)) for td in list_td))
 
 
 def _moving_average_by_time(times, data, delta, num):
@@ -2580,7 +2587,7 @@ class Beatmap:
         """
         def pack_field(field, field_value,
                        pack_func, default, skip_empty=False):
-            packed_field_str = pack_func(field, field_value, default)
+            packed_field_str = pack_func(field, field_value, default=default)
             # if ``skip_empty`` is True, empty string will be
             # returned for empty fields
             if skip_empty and packed_field_str == '':
@@ -2620,7 +2627,8 @@ class Beatmap:
         # Bookmarks field actually does not even exist in .osu file
         # if there's no bookmark at all.
         packed_str += pack_field('Bookmarks', self.bookmarks,
-                                 _pack_timedelta_list, [], skip_empty=True)
+                                 partial(_pack_timedelta_list, sep=','),
+                                 [], skip_empty=True)
         packed_str += pack_field('DistanceSpacing', self.distance_spacing,
                                  _pack_float, 1.0)
         packed_str += pack_field('BeatDivisor', self.beat_divisor,
@@ -2653,7 +2661,8 @@ class Beatmap:
         packed_str += pack_field('Source', self.source,
                                  _pack_str, '')
         packed_str += pack_field('Tags', self.tags,
-                                 _pack_str_list, '')
+                                 partial(_pack_str_list, sep=' '),
+                                 '')
         packed_str += pack_field('BeatmapID', self.beatmap_id,
                                  _pack_int, 0)
         packed_str += pack_field('BeatmapSetID', self.beatmap_set_id,

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -2311,7 +2311,7 @@ class Beatmap:
             Raised when the ``Beatmap`` object is invalid to be
             written to a ``.osu`` file.
         """
-        with open(path, mode='rt', encoding='utf-8-sig') as file:
+        with open(path, mode='wt', encoding='utf-8-sig') as file:
             self.write_file(file)
 
     def write_file(self, file):

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -9,6 +9,7 @@ from zipfile import ZipFile
 
 import numpy as np
 
+from .abc import abstractmethod
 from .game_mode import GameMode
 from .mod import ar_to_ms, ms_to_ar, circle_radius, od_to_ms_300, ms_300_to_od
 from .position import Position, Point, distance
@@ -216,6 +217,28 @@ class TimingPoint:
             kiai_mode=kiai_mode,
         )
 
+    def pack(self):
+        """The string representing this timing point used in ``.osu`` file, without trailing ``\\n``.
+
+        Returns
+        -------
+        packed_str : str
+            The packed str of this timing point.
+
+        Raises
+        ------
+        ValueError
+            Raised when essential member values are missing or are of incorrect type.
+        """
+        return ','.join([_pack_timedelta('time', self.offset),
+                         _pack_float('beatLength', self.ms_per_beat),
+                         _pack_int('meter', self.meter),
+                         _pack_int('sampleSet', self.sample_type),
+                         _pack_int('sampleIndex', self.sample_set),
+                         _pack_int('volume', int(self.volume)),
+                         '1' if self.parent is None else '0',
+                         _pack_bool('effects', self.kiai_mode)])
+
 
 class HitObject:
     """An abstract hit element for osu! standard.
@@ -233,7 +256,7 @@ class HitObject:
     """
     time_related_attributes = frozenset({'time'})
 
-    def __init__(self, position, time, hitsound, addition='0:0:0:0'):
+    def __init__(self, position, time, hitsound, addition='0:0:0:0:'):
         self.position = position
         self.time = time
         self.hitsound = hitsound
@@ -397,6 +420,22 @@ class HitObject:
 
         return parse(Position(x, y), time, hitsound, rest)
 
+    @abstractmethod
+    def pack(self):
+        """The string representing this hit element used in .osu file, without trailing ``\\n``.
+
+        Returns
+        -------
+        packed_str : str
+            The packed str of this hit element.
+
+        Raises
+        ------
+        ValueError
+            Raised when essential member values are missing or are of incorrect type.
+        """
+        raise NotImplementedError('pack')
+
 
 class Circle(HitObject):
     """A circle hit element.
@@ -416,6 +455,27 @@ class Circle(HitObject):
             raise ValueError('extra data: {rest!r}')
 
         return cls(position, time, hitsound, *rest)
+
+    def pack(self):
+        """The string representing this circle hit element used in ``.osu`` file, without trailing ``\\n``.
+
+        Returns
+        -------
+        packed_str : str
+            The packed str of this circle hit element.
+
+        Raises
+        ------
+        ValueError
+            Raised when essential member values are missing or are of incorrect type.
+        """
+        # Circles do not have objectParams
+        return ','.join([_pack_float('x', self.position.x),
+                         _pack_float('y', self.position.y),
+                         _pack_timedelta('time', self.time),
+                         _pack_int('type', Circle.type_code),
+                         _pack_int('hitSound', self.hitsound),
+                         _pack_str('hitSample', self.addition)])
 
 
 class Spinner(HitObject):
@@ -461,6 +521,27 @@ class Spinner(HitObject):
 
         return cls(position, time, hitsound, end_time, *rest)
 
+    def pack(self):
+        """The string representing this spinner hit element used in ``.osu`` file, without trailing ``\\n``.
+
+        Returns
+        -------
+        packed_str : str
+            The packed str of this spinner hit element.
+
+        Raises
+        ------
+        ValueError
+            Raised when essential member values are missing or are of incorrect type.
+        """
+        return ','.join([_pack_float('x', self.position.x),
+                         _pack_float('y', self.position.y),
+                         _pack_timedelta('time', self.time),
+                         _pack_int('type', Spinner.type_code),
+                         _pack_int('hitSound', self.hitsound),
+                         _pack_timedelta('endTime', self.end_time),
+                         _pack_str('hitSample', self.addition)])
+
 
 class Slider(HitObject):
     """A slider hit element.
@@ -477,7 +558,7 @@ class Slider(HitObject):
         The sound played on the ticks of the slider.
     curve : Curve
         The slider's curve function.
-    length : int
+    length : float
         The length of this slider in osu! pixels.
     ticks : int
         The number of slider ticks including the head and tail of the slider.
@@ -512,7 +593,7 @@ class Slider(HitObject):
                  ms_per_beat,
                  edge_sounds,
                  edge_additions,
-                 addition='0:0:0:0'):
+                 addition='0:0:0:0:'):
         super().__init__(position, time, hitsound, addition)
         self.end_time = end_time
         self.curve = curve
@@ -731,6 +812,31 @@ class Slider(HitObject):
             *rest,
         )
 
+    def pack(self):
+        """The string representing this slider hit element used in ``.osu`` file, without trailing ``\\n``.
+
+        Returns
+        -------
+        packed_str : str
+            The packed str of this slider hit element.
+
+        Raises
+        ------
+        ValueError
+            Raised when essential member values are missing or are of incorrect type.
+        """
+        return ','.join([_pack_float('x', self.position.x),
+                         _pack_float('y', self.position.y),
+                         _pack_timedelta('time', self.time),
+                         _pack_int('type', Slider.type_code),
+                         _pack_int('hitSound', self.hitsound),
+                         self.curve.pack(),
+                         _pack_int('slides', self.repeat),
+                         _pack_float('length', self.length),
+                         '|'.join(_pack_int('edgeSound', edge_sound) for edge_sound in self.edge_sounds),
+                         '|'.join(_pack_str('edgeSet', edge_addition) for edge_addition in self.edge_additions),
+                         _pack_str('hitSample', self.addition)])
+
 
 class HoldNote(HitObject):
     """A HoldNote hit element.
@@ -747,13 +853,55 @@ class HoldNote(HitObject):
     A ``HoldNote`` can only appear in an osu!mania map.
     """
     type_code = 128
+    time_related_attributes = frozenset({'time', 'end_time'})
+
+    def __init__(self,
+                 position,
+                 time,
+                 hitsound,
+                 end_time,
+                 addition='0:0:0:0:'):
+        super().__init__(position, time, hitsound, addition)
+        self.end_time = end_time
 
     @classmethod
     def _parse(cls, position, time, hitsound, rest):
+        try:
+            end_time, *rest = rest
+        except ValueError:
+            raise ValueError('missing end_time')
+
+        try:
+            end_time = timedelta(milliseconds=int(end_time))
+        except ValueError:
+            raise ValueError(f'end_time should be an int, got {end_time!r}')
         if len(rest) > 1:
             raise ValueError('extra data: {rest!r}')
 
-        return cls(position, time, hitsound, *rest)
+        return cls(position, time, hitsound, end_time, *rest)
+
+    def pack(self):
+        """The string representing this HoldNote hit element used in ``.osu`` file, without trailing ``\\n``.
+
+        Returns
+        -------
+        packed_str : str
+            The packed str of this HoldNote hit element.
+
+        Raises
+        ------
+        ValueError
+            Raised when essential member values are missing or are of incorrect type.
+        """
+        # HoldNotes differ with Sliders in that their endTime is joined with hitSample
+        # with ':' rather than with ','
+        return ','.join([_pack_int('x', self.position.x),
+                         _pack_int('y', self.position.y),
+                         _pack_timedelta('time', self.time),
+                         _pack_int('type', HoldNote.type_code),
+                         _pack_int('hitSound', self.hitsound),
+                         ':'.join([_pack_timedelta('endTime', self.end_time),
+                                   _pack_str('hitSample', self.addition)])])
 
 
 def _get_as_str(groups, section, field, default=no_default):
@@ -927,6 +1075,254 @@ def _get_as_bool(groups, section, field, default=no_default):
             f'field {field!r} in section {section!r} should be a bool,'
             f' got {v!r}',
         )
+
+
+def _replace_invalid_with_default(field: str, field_value, expected_type, default=no_default):
+    """
+    Replaces the field_value with default value if it is invalid (missing or of incorrect type).
+
+    Parameters
+    ----------
+    field : str
+        The name of the field.
+    field_value : Any
+        Field value.
+    expected_type : Any
+        The expected type of ``field_value``.
+    default : float, optional
+        A value to return if ``field`` is invalid.
+
+    Returns
+    -------
+    field_value : Any
+        Valid ``field_value``
+
+    Raises
+    ------
+    ValueError
+        Raised when ``field_value`` is missing or is of incorrect type, but no default value is available.
+    """
+    if isinstance(field_value, expected_type):
+        return field_value
+    else:
+        if default is no_default:
+            raise ValueError(
+                f'field {field!r} should be a {expected_type.__name__!r},'
+                f' got {field_value.__class__.__name__!r}',
+            )
+        else:
+            return default
+
+
+def _pack_timedelta(field: str, td: timedelta, default=no_default):
+    """Pack timedelta to a string.
+
+    Parameters
+    ----------
+    field : str
+        The name  of the field to be packed.
+    td : timedelta
+        The value to be packed to string.
+    default : timedelta, optional
+        A value to return if ``td`` is not valid.
+
+    Returns
+    -------
+    packed_str : str
+        The packed str.
+
+    Raises
+    ------
+    ValueError
+        Raised when ``td`` is not a timedelta and default is not available.
+    """
+    td = _replace_invalid_with_default(field, td, timedelta, default)
+    return str(td // timedelta(milliseconds=1))
+
+
+def _pack_bool(field: str, bool_in: bool, default=no_default):
+    """Pack bool to a string.
+
+    Parameters
+    ----------
+    field : str
+        The name  of the field to be packed.
+    bool_in : bool
+        The value to be packed to string.
+    default : bool, optional
+        A value to return if ``bool_in`` is not valid.
+
+    Returns
+    -------
+    packed_str : str
+        The packed str.
+
+    Raises
+    ------
+    ValueError
+        Raised when ``bool_in`` is not a bool and default is not available.
+    """
+    bool_in = _replace_invalid_with_default(field, bool_in, bool, default)
+    return '1' if bool_in else '0'
+
+
+def _pack_int(field: str, int_in: int, default=no_default):
+    """Pack int to a string.
+
+    Parameters
+    ----------
+    field : str
+        The name  of the field to be packed.
+    int_in : int
+        The value to be packed to string.
+    default : int, optional
+        A value to return if ``int_in`` is not valid.
+
+    Returns
+    -------
+    packed_str : str
+        The packed str.
+
+    Raises
+    ------
+    ValueError
+        Raised when ``int_in`` is not a int and default is not available.
+    """
+    int_in = _replace_invalid_with_default(field, int_in, int, default)
+    return str(int(int_in))
+
+
+def _pack_float(field: str, float_in: float or int, default=no_default):
+    """Pack float to a string. If the float number can be converted to int without loss,
+    return the packed string of the converted int.
+
+    Parameters
+    ----------
+    field : str
+        The name  of the field to be packed.
+    float_in : float
+        The value to be packed to string.
+    default : float, optional
+        A value to return if ``float_in`` is not valid.
+
+    Returns
+    -------
+    packed_str : str
+        The packed str.
+
+    Raises
+    ------
+    ValueError
+        Raised when ``float_in`` is not a float and default is not available.
+    """
+    float_in = _replace_invalid_with_default(field, float_in, (int, float), default)
+    # try to give out an int-like string when packing float fields, as osu! client does
+    int_ = int(float_in)
+    return str(int_) if int_ == float_in else str(float_in)
+
+
+def _pack_str(field: str, str_in: str, default=no_default):
+    """Pack string to a string, with validity check.
+
+    Parameters
+    ----------
+    field : str
+        The name  of the field to be packed.
+    str_in : str
+        The value to be packed to string.
+    default : str, optional
+        A value to return if ``str_in`` is not valid.
+
+    Returns
+    -------
+    packed_str : str
+        The packed str.
+
+    Raises
+    ------
+    ValueError
+        Raised when ``str_in`` is not a str and default is not available.
+    """
+    str_in = _replace_invalid_with_default(field, str_in, str, default)
+    return str_in
+
+
+def _pack_int_enum(field: str, enum_in: IntEnum, default=no_default):
+    """Pack IntEnum to a string.
+
+    Parameters
+    ----------
+    field : str
+        The name  of the field to be packed.
+    enum_in : IntEnum
+        The value to be packed to string.
+    default : IntEnum, optional
+        A value to return if ``enum_in`` is not valid.
+
+    Returns
+    -------
+    packed_str : str
+        The packed str.
+
+    Raises
+    ------
+    ValueError
+        Raised when ``enum_in`` is not a IntEnum and default is not available.
+    """
+    enum_in = _replace_invalid_with_default(field, enum_in, IntEnum, default)
+    return str(int(enum_in))
+
+
+def _pack_str_list(field: str, list_str: list, default=no_default):
+    """Pack a list of string to a string, with space as separator between elements.
+
+    Parameters
+    ----------
+    field : str
+        The name  of the field to be packed.
+    list_str : list
+        The value to be packed to string.
+    default : list, optional
+        A value to return if ``list_str`` is not valid.
+
+    Returns
+    -------
+    packed_str : str
+        The packed str.
+
+    Raises
+    ------
+    ValueError
+        Raised when ``list_str`` is not a list of str and default is not available.
+    """
+    list_str = _replace_invalid_with_default(field, list_str, list, default)
+    return ' '.join(list_str)
+
+
+def _pack_int_list(field: str, list_int: list, default=no_default):
+    """Pack a list of int to a string, with space as separator between elements.
+
+    Parameters
+    ----------
+    field : str
+        The name  of the field to be packed.
+    list_int : list
+        The value to be packed to string.
+    default : list, optional
+        A value to return if ``list_int`` is not valid.
+
+    Returns
+    -------
+    packed_str : str
+        The packed str.
+
+    Raises
+    ------
+    ValueError
+        Raised when ``list_int`` is not a list of int and default is not available.
+    """
+    list_int = _replace_invalid_with_default(field, list_int, list, default)
+    return ' '.join((str(int_) for int_ in list_int))
 
 
 def _moving_average_by_time(times, data, delta, num):
@@ -1881,6 +2277,37 @@ class Beatmap:
         'Difficulty',
     })
 
+    def write_path(self, path):
+        """Write a ``Beatmap`` object to a file on disk.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            The path to the file to write to.
+
+        Raises
+        ------
+        ValueError
+            Raised when the ``Beatmap`` object is invalid to be written to a ``.osu`` file.
+        """
+        with open(path, mode='rt', encoding='utf-8-sig') as file:
+            self.write_file(file)
+
+    def write_file(self, file):
+        """Write a ``Beatmap`` object to an open file object.
+
+        Parameters
+        ----------
+        file : file-like
+            The file object to write to.
+
+        Raises
+        ------
+        ValueError
+            Raised when the ``Beatmap`` object is invalid to be written to a ``.osu`` file.
+        """
+        file.write(self.pack())
+
     @classmethod
     def _find_groups(cls, lines):
         """Split the input data into the named groups.
@@ -2111,6 +2538,109 @@ class Beatmap:
             )),
 
         )
+
+    def pack(self):
+        """The string content in ``.osu`` file of this beatmap.
+        Default values assumed by osu! client Beatmap editor are used to replace member values
+        which are missing or are of incorrect type.
+
+        Returns
+        -------
+        packed_str : str
+            The packed str of this beatmap
+
+        Raises
+        ------
+        ValueError
+            Raised when essential member values are missing or are of incorrect type.
+        """
+        def pack_field(field, field_value, pack_func, default):
+            return field + ':' + pack_func(field, field_value, default) + '\n'
+
+        packed_str = 'osu file format v14\n\n'
+
+        # pack General section
+        packed_str += '[General]\n'
+        packed_str += pack_field('AudioFilename', self.audio_filename, _pack_str, no_default)
+        packed_str += pack_field('AudioLeadIn', self.audio_lead_in, _pack_timedelta, timedelta(milliseconds=0))
+        packed_str += pack_field('PreviewTime', self.preview_time, _pack_timedelta, timedelta(milliseconds=-1))
+        packed_str += pack_field('Countdown', self.countdown, _pack_bool, False)
+        packed_str += pack_field('SampleSet', self.sample_set, _pack_str, 'None')
+        packed_str += pack_field('StackLeniency', self.stack_leniency, _pack_float, 0)
+        packed_str += pack_field('Mode', self.mode, _pack_int_enum, GameMode.standard)
+        packed_str += pack_field('LetterboxInBreaks', self.letterbox_in_breaks, _pack_bool, False)
+        packed_str += pack_field('WidescreenStoryboard', self.widescreen_storyboard, _pack_bool, False)
+        packed_str += '\n'
+
+        # pack Editor section
+        packed_str += '[Editor]\n'
+        # Bookmarks field actually does not even exist in .osu file if there's no bookmark at all.
+        packed_str += pack_field('Bookmarks', self.bookmarks, _pack_int_list, [])
+        packed_str += pack_field('DistanceSpacing', self.distance_spacing, _pack_float, 1.0)
+        packed_str += pack_field('BeatDivisor', self.beat_divisor, _pack_int, 4)
+        packed_str += pack_field('GridSize', self.grid_size, _pack_int, 4)
+        packed_str += pack_field('TimelineZoom', self.timeline_zoom, _pack_float, 1.0)
+        packed_str += '\n'
+
+        # pack Metadata section
+        packed_str += '[Metadata]\n'
+        # osu! beatmap editor forces mappers to enter Title, Artist, Creator, Version fields when creating a new
+        # beatmap from an audio file, so these fields are considered indispensable for a valid Beatmap.
+        # When packing a Beatmap, ValueError will be raised if these fields do not have sensible values.
+        packed_str += pack_field('Title', self.title, _pack_str, no_default)
+        packed_str += pack_field('TitleUnicode', self.title_unicode, _pack_str, self.title)
+        packed_str += pack_field('Artist', self.artist, _pack_str, no_default)
+        packed_str += pack_field('ArtistUnicode', self.artist_unicode, _pack_str, self.artist)
+        packed_str += pack_field('Creator', self.creator, _pack_str, no_default)
+        packed_str += pack_field('Version', self.version, _pack_str, no_default)
+        packed_str += pack_field('Source', self.source, _pack_str, '')
+        packed_str += pack_field('Tags', self.tags, _pack_str_list, '')
+        packed_str += pack_field('BeatmapID', self.beatmap_id, _pack_int, 0)
+        packed_str += pack_field('BeatmapSetID', self.beatmap_set_id, _pack_int, -1)
+        packed_str += '\n'
+
+        # pack Difficulty section
+        packed_str += '[Difficulty]\n'
+        packed_str += pack_field('HPDrainRate', self.hp_drain_rate, _pack_float, 5.0)
+        packed_str += pack_field('CircleSize', self.circle_size, _pack_float, 5.0)
+        packed_str += pack_field('OverallDifficulty', self.overall_difficulty, _pack_float, 5.0)
+        packed_str += pack_field('ApproachRate', self.approach_rate, _pack_float, 5.0)
+        packed_str += pack_field('SliderMultiplier', self.slider_multiplier, _pack_float, 1.4)
+        packed_str += pack_field('SliderTickRate', self.slider_tick_rate, _pack_float, 1.0)
+        packed_str += '\n'
+
+        # pack Events section
+        packed_str += '[Events]\n'
+        packed_str += '// Background and Video events\n' \
+                      '// Break Periods\n' \
+                      '// Storyboard Layer 0(Background)\n' \
+                      '// Storyboard Layer 1(Fail)\n' \
+                      '// Storyboard Layer 2(Pass)\n' \
+                      '// Storyboard Layer 3(Foreground)\n' \
+                      '// Storyboard Layer 4(Overlay)\n' \
+                      '// Storyboard Sound Samples\n'
+        packed_str += '\n'
+
+        # pack TimingPoints section
+        packed_str += '[TimingPoints]\n'
+        for timing_point in self.timing_points:
+            # each timing point occupies a line
+            packed_str += timing_point.pack() + '\n'
+        packed_str += '\n'
+
+        # pack Colours section
+        # packed_str += '[Colours]\n'
+        # # TODO
+        # packed_str += '\n'
+
+        # pack HitObjects section
+        packed_str += '[HitObjects]\n'
+        for hit_object in self.hit_objects():
+            # each hit object occupies a line
+            packed_str += hit_object.pack() + '\n'
+        packed_str += '\n'
+
+        return packed_str
 
     def timing_point_at(self, time):
         """Get the :class:`slider.beatmap.TimingPoint` at the given time.

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -2616,10 +2616,17 @@ class Beatmap:
 
         # pack Editor section
         packed_str += '[Editor]\n'
+
+        def _pack_bookmarks(_field, bookmarks, _default=no_default):
+            bookmarks = [
+                str(b // timedelta(milliseconds=1)) for b in bookmarks
+            ]
+            return ",".join(bookmarks)
+
         # Bookmarks field actually does not even exist in .osu file
         # if there's no bookmark at all.
         packed_str += pack_field('Bookmarks', self.bookmarks,
-                                 _pack_int_list, [], skip_empty=True)
+                                 _pack_bookmarks, [], skip_empty=True)
         packed_str += pack_field('DistanceSpacing', self.distance_spacing,
                                  _pack_float, 1.0)
         packed_str += pack_field('BeatDivisor', self.beat_divisor,

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -2584,8 +2584,7 @@ class Beatmap:
             # returned for empty fields
             if skip_empty and packed_field_str == '':
                 return ''
-            else:
-                return field + ':' + packed_field_str + '\n'
+            return field + ':' + packed_field_str + '\n'
 
         packed_str = 'osu file format v14\n\n'
 

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -218,7 +218,8 @@ class TimingPoint:
         )
 
     def pack(self):
-        """The string representing this timing point used in ``.osu`` file, without trailing ``\\n``.
+        """The string representing this timing point used in ``.osu`` file,
+        without trailing ``\\n``.
 
         Returns
         -------
@@ -228,7 +229,8 @@ class TimingPoint:
         Raises
         ------
         ValueError
-            Raised when essential member values are missing or are of incorrect type.
+            Raised when essential member values are missing
+            or are of incorrect type.
         """
         return ','.join([_pack_timedelta('time', self.offset),
                          _pack_float('beatLength', self.ms_per_beat),
@@ -422,7 +424,8 @@ class HitObject:
 
     @abstractmethod
     def pack(self):
-        """The string representing this hit element used in .osu file, without trailing ``\\n``.
+        """The string representing this hit element used in .osu file,
+        without trailing ``\\n``.
 
         Returns
         -------
@@ -432,7 +435,8 @@ class HitObject:
         Raises
         ------
         ValueError
-            Raised when essential member values are missing or are of incorrect type.
+            Raised when essential member values are missing
+            or are of incorrect type.
         """
         raise NotImplementedError('pack')
 
@@ -457,7 +461,8 @@ class Circle(HitObject):
         return cls(position, time, hitsound, *rest)
 
     def pack(self):
-        """The string representing this circle hit element used in ``.osu`` file, without trailing ``\\n``.
+        """The string representing this circle hit element used in ``.osu`` file,
+        without trailing ``\\n``.
 
         Returns
         -------
@@ -467,7 +472,8 @@ class Circle(HitObject):
         Raises
         ------
         ValueError
-            Raised when essential member values are missing or are of incorrect type.
+            Raised when essential member values are missing
+            or are of incorrect type.
         """
         # Circles do not have objectParams
         return ','.join([_pack_float('x', self.position.x),
@@ -522,7 +528,8 @@ class Spinner(HitObject):
         return cls(position, time, hitsound, end_time, *rest)
 
     def pack(self):
-        """The string representing this spinner hit element used in ``.osu`` file, without trailing ``\\n``.
+        """The string representing this spinner hit element used in ``.osu`` file,
+        without trailing ``\\n``.
 
         Returns
         -------
@@ -532,7 +539,8 @@ class Spinner(HitObject):
         Raises
         ------
         ValueError
-            Raised when essential member values are missing or are of incorrect type.
+            Raised when essential member values are missing
+            or are of incorrect type.
         """
         return ','.join([_pack_float('x', self.position.x),
                          _pack_float('y', self.position.y),
@@ -813,7 +821,8 @@ class Slider(HitObject):
         )
 
     def pack(self):
-        """The string representing this slider hit element used in ``.osu`` file, without trailing ``\\n``.
+        """The string representing this slider hit element used in ``.osu`` file,
+        without trailing ``\\n``.
 
         Returns
         -------
@@ -823,7 +832,8 @@ class Slider(HitObject):
         Raises
         ------
         ValueError
-            Raised when essential member values are missing or are of incorrect type.
+            Raised when essential member values are missing
+            or are of incorrect type.
         """
         return ','.join([_pack_float('x', self.position.x),
                          _pack_float('y', self.position.y),
@@ -833,8 +843,10 @@ class Slider(HitObject):
                          self.curve.pack(),
                          _pack_int('slides', self.repeat),
                          _pack_float('length', self.length),
-                         '|'.join(_pack_int('edgeSound', edge_sound) for edge_sound in self.edge_sounds),
-                         '|'.join(_pack_str('edgeSet', edge_addition) for edge_addition in self.edge_additions),
+                         '|'.join(_pack_int('edgeSound', edge_sound)
+                                  for edge_sound in self.edge_sounds),
+                         '|'.join(_pack_str('edgeSet', edge_addition)
+                                  for edge_addition in self.edge_additions),
                          _pack_str('hitSample', self.addition)])
 
 
@@ -881,7 +893,8 @@ class HoldNote(HitObject):
         return cls(position, time, hitsound, end_time, *rest)
 
     def pack(self):
-        """The string representing this HoldNote hit element used in ``.osu`` file, without trailing ``\\n``.
+        """The string representing this HoldNote hit element used in ``.osu`` file,
+        without trailing ``\\n``.
 
         Returns
         -------
@@ -891,10 +904,11 @@ class HoldNote(HitObject):
         Raises
         ------
         ValueError
-            Raised when essential member values are missing or are of incorrect type.
+            Raised when essential member values are missing
+            or are of incorrect type.
         """
-        # HoldNotes differ with Sliders in that their endTime is joined with hitSample
-        # with ':' rather than with ','
+        # HoldNotes differ with Sliders in that their endTime is
+        # joined with hitSample with ':' rather than with ','
         return ','.join([_pack_int('x', self.position.x),
                          _pack_int('y', self.position.y),
                          _pack_timedelta('time', self.time),
@@ -1077,9 +1091,11 @@ def _get_as_bool(groups, section, field, default=no_default):
         )
 
 
-def _replace_invalid_with_default(field: str, field_value, expected_type, default=no_default):
+def _invalid_to_default(field: str, field_value, expected_type,
+                        default=no_default):
     """
-    Replaces the field_value with default value if it is invalid (missing or of incorrect type).
+    Replaces the field_value with default value if it is invalid
+    (missing or of incorrect type).
 
     Parameters
     ----------
@@ -1100,7 +1116,8 @@ def _replace_invalid_with_default(field: str, field_value, expected_type, defaul
     Raises
     ------
     ValueError
-        Raised when ``field_value`` is missing or is of incorrect type, but no default value is available.
+        Raised when ``field_value`` is missing or is of incorrect type,
+        but no default value is available.
     """
     if isinstance(field_value, expected_type):
         return field_value
@@ -1136,7 +1153,7 @@ def _pack_timedelta(field: str, td: timedelta, default=no_default):
     ValueError
         Raised when ``td`` is not a timedelta and default is not available.
     """
-    td = _replace_invalid_with_default(field, td, timedelta, default)
+    td = _invalid_to_default(field, td, timedelta, default)
     return str(td // timedelta(milliseconds=1))
 
 
@@ -1162,7 +1179,7 @@ def _pack_bool(field: str, bool_in: bool, default=no_default):
     ValueError
         Raised when ``bool_in`` is not a bool and default is not available.
     """
-    bool_in = _replace_invalid_with_default(field, bool_in, bool, default)
+    bool_in = _invalid_to_default(field, bool_in, bool, default)
     return '1' if bool_in else '0'
 
 
@@ -1188,13 +1205,13 @@ def _pack_int(field: str, int_in: int, default=no_default):
     ValueError
         Raised when ``int_in`` is not a int and default is not available.
     """
-    int_in = _replace_invalid_with_default(field, int_in, int, default)
+    int_in = _invalid_to_default(field, int_in, int, default)
     return str(int(int_in))
 
 
 def _pack_float(field: str, float_in: float or int, default=no_default):
-    """Pack float to a string. If the float number can be converted to int without loss,
-    return the packed string of the converted int.
+    """Pack float to a string. If the float number can be converted to
+    int without loss, return the packed string of the converted int.
 
     Parameters
     ----------
@@ -1215,8 +1232,9 @@ def _pack_float(field: str, float_in: float or int, default=no_default):
     ValueError
         Raised when ``float_in`` is not a float and default is not available.
     """
-    float_in = _replace_invalid_with_default(field, float_in, (int, float), default)
-    # try to give out an int-like string when packing float fields, as osu! client does
+    float_in = _invalid_to_default(field, float_in, (int, float), default)
+    # try to give out an int-like string when packing float fields,
+    # as osu! client does
     int_ = int(float_in)
     return str(int_) if int_ == float_in else str(float_in)
 
@@ -1243,7 +1261,7 @@ def _pack_str(field: str, str_in: str, default=no_default):
     ValueError
         Raised when ``str_in`` is not a str and default is not available.
     """
-    str_in = _replace_invalid_with_default(field, str_in, str, default)
+    str_in = _invalid_to_default(field, str_in, str, default)
     return str_in
 
 
@@ -1269,7 +1287,7 @@ def _pack_int_enum(field: str, enum_in: IntEnum, default=no_default):
     ValueError
         Raised when ``enum_in`` is not a IntEnum and default is not available.
     """
-    enum_in = _replace_invalid_with_default(field, enum_in, IntEnum, default)
+    enum_in = _invalid_to_default(field, enum_in, IntEnum, default)
     return str(int(enum_in))
 
 
@@ -1293,9 +1311,10 @@ def _pack_str_list(field: str, list_str: list, default=no_default):
     Raises
     ------
     ValueError
-        Raised when ``list_str`` is not a list of str and default is not available.
+        Raised when ``list_str`` is not a list of str
+        and default is not available.
     """
-    list_str = _replace_invalid_with_default(field, list_str, list, default)
+    list_str = _invalid_to_default(field, list_str, list, default)
     return ' '.join(list_str)
 
 
@@ -1319,9 +1338,10 @@ def _pack_int_list(field: str, list_int: list, default=no_default):
     Raises
     ------
     ValueError
-        Raised when ``list_int`` is not a list of int and default is not available.
+        Raised when ``list_int`` is not a list of int
+        and default is not available.
     """
-    list_int = _replace_invalid_with_default(field, list_int, list, default)
+    list_int = _invalid_to_default(field, list_int, list, default)
     return ' '.join((str(int_) for int_ in list_int))
 
 
@@ -2288,7 +2308,8 @@ class Beatmap:
         Raises
         ------
         ValueError
-            Raised when the ``Beatmap`` object is invalid to be written to a ``.osu`` file.
+            Raised when the ``Beatmap`` object is invalid to be
+            written to a ``.osu`` file.
         """
         with open(path, mode='rt', encoding='utf-8-sig') as file:
             self.write_file(file)
@@ -2304,7 +2325,8 @@ class Beatmap:
         Raises
         ------
         ValueError
-            Raised when the ``Beatmap`` object is invalid to be written to a ``.osu`` file.
+            Raised when the ``Beatmap`` object is invalid to be
+            written to a ``.osu`` file.
         """
         file.write(self.pack())
 
@@ -2541,8 +2563,8 @@ class Beatmap:
 
     def pack(self):
         """The string content in ``.osu`` file of this beatmap.
-        Default values assumed by osu! client Beatmap editor are used to replace member values
-        which are missing or are of incorrect type.
+        Default values assumed by osu! client Beatmap editor are used to
+        replace member values which are missing or are of incorrect type.
 
         Returns
         -------
@@ -2552,61 +2574,103 @@ class Beatmap:
         Raises
         ------
         ValueError
-            Raised when essential member values are missing or are of incorrect type.
+            Raised when essential member values are missing
+            or are of incorrect type.
         """
-        def pack_field(field, field_value, pack_func, default):
-            return field + ':' + pack_func(field, field_value, default) + '\n'
+        def pack_field(field, field_value,
+                       pack_func, default, skip_empty=False):
+            packed_field_str = pack_func(field, field_value, default)
+            # if ``skip_empty`` is True, empty string will be
+            # returned for empty fields
+            if skip_empty and packed_field_str == '':
+                return ''
+            else:
+                return field + ':' + packed_field_str + '\n'
 
         packed_str = 'osu file format v14\n\n'
 
         # pack General section
         packed_str += '[General]\n'
-        packed_str += pack_field('AudioFilename', self.audio_filename, _pack_str, no_default)
-        packed_str += pack_field('AudioLeadIn', self.audio_lead_in, _pack_timedelta, timedelta(milliseconds=0))
-        packed_str += pack_field('PreviewTime', self.preview_time, _pack_timedelta, timedelta(milliseconds=-1))
-        packed_str += pack_field('Countdown', self.countdown, _pack_bool, False)
-        packed_str += pack_field('SampleSet', self.sample_set, _pack_str, 'None')
-        packed_str += pack_field('StackLeniency', self.stack_leniency, _pack_float, 0)
-        packed_str += pack_field('Mode', self.mode, _pack_int_enum, GameMode.standard)
-        packed_str += pack_field('LetterboxInBreaks', self.letterbox_in_breaks, _pack_bool, False)
-        packed_str += pack_field('WidescreenStoryboard', self.widescreen_storyboard, _pack_bool, False)
+        packed_str += pack_field('AudioFilename', self.audio_filename,
+                                 _pack_str, no_default)
+        packed_str += pack_field('AudioLeadIn', self.audio_lead_in,
+                                 _pack_timedelta, timedelta(milliseconds=0))
+        packed_str += pack_field('PreviewTime', self.preview_time,
+                                 _pack_timedelta, timedelta(milliseconds=-1))
+        packed_str += pack_field('Countdown', self.countdown,
+                                 _pack_bool, False)
+        packed_str += pack_field('SampleSet', self.sample_set,
+                                 _pack_str, 'None')
+        packed_str += pack_field('StackLeniency', self.stack_leniency,
+                                 _pack_float, 0)
+        packed_str += pack_field('Mode', self.mode,
+                                 _pack_int_enum, GameMode.standard)
+        packed_str += pack_field('LetterboxInBreaks', self.letterbox_in_breaks,
+                                 _pack_bool, False)
+        packed_str += pack_field('WidescreenStoryboard',
+                                 self.widescreen_storyboard,
+                                 _pack_bool, False)
         packed_str += '\n'
 
         # pack Editor section
         packed_str += '[Editor]\n'
-        # Bookmarks field actually does not even exist in .osu file if there's no bookmark at all.
-        packed_str += pack_field('Bookmarks', self.bookmarks, _pack_int_list, [])
-        packed_str += pack_field('DistanceSpacing', self.distance_spacing, _pack_float, 1.0)
-        packed_str += pack_field('BeatDivisor', self.beat_divisor, _pack_int, 4)
-        packed_str += pack_field('GridSize', self.grid_size, _pack_int, 4)
-        packed_str += pack_field('TimelineZoom', self.timeline_zoom, _pack_float, 1.0)
+        # Bookmarks field actually does not even exist in .osu file
+        # if there's no bookmark at all.
+        packed_str += pack_field('Bookmarks', self.bookmarks,
+                                 _pack_int_list, [], skip_empty=True)
+        packed_str += pack_field('DistanceSpacing', self.distance_spacing,
+                                 _pack_float, 1.0)
+        packed_str += pack_field('BeatDivisor', self.beat_divisor,
+                                 _pack_int, 4)
+        packed_str += pack_field('GridSize', self.grid_size,
+                                 _pack_int, 4)
+        packed_str += pack_field('TimelineZoom', self.timeline_zoom,
+                                 _pack_float, 1.0)
         packed_str += '\n'
 
         # pack Metadata section
         packed_str += '[Metadata]\n'
-        # osu! beatmap editor forces mappers to enter Title, Artist, Creator, Version fields when creating a new
-        # beatmap from an audio file, so these fields are considered indispensable for a valid Beatmap.
-        # When packing a Beatmap, ValueError will be raised if these fields do not have sensible values.
-        packed_str += pack_field('Title', self.title, _pack_str, no_default)
-        packed_str += pack_field('TitleUnicode', self.title_unicode, _pack_str, self.title)
-        packed_str += pack_field('Artist', self.artist, _pack_str, no_default)
-        packed_str += pack_field('ArtistUnicode', self.artist_unicode, _pack_str, self.artist)
-        packed_str += pack_field('Creator', self.creator, _pack_str, no_default)
-        packed_str += pack_field('Version', self.version, _pack_str, no_default)
-        packed_str += pack_field('Source', self.source, _pack_str, '')
-        packed_str += pack_field('Tags', self.tags, _pack_str_list, '')
-        packed_str += pack_field('BeatmapID', self.beatmap_id, _pack_int, 0)
-        packed_str += pack_field('BeatmapSetID', self.beatmap_set_id, _pack_int, -1)
+        # osu! beatmap editor forces mappers to enter Title, Artist,
+        # Creator, Version fields when creating a new beatmap from
+        # an audio file, so these fields are considered indispensable
+        # for a valid Beatmap. When packing a Beatmap, ValueError will
+        # be raised if these fields do not have sensible values.
+        packed_str += pack_field('Title', self.title,
+                                 _pack_str, no_default)
+        packed_str += pack_field('TitleUnicode', self.title_unicode,
+                                 _pack_str, self.title)
+        packed_str += pack_field('Artist', self.artist,
+                                 _pack_str, no_default)
+        packed_str += pack_field('ArtistUnicode', self.artist_unicode,
+                                 _pack_str, self.artist)
+        packed_str += pack_field('Creator', self.creator,
+                                 _pack_str, no_default)
+        packed_str += pack_field('Version', self.version,
+                                 _pack_str, no_default)
+        packed_str += pack_field('Source', self.source,
+                                 _pack_str, '')
+        packed_str += pack_field('Tags', self.tags,
+                                 _pack_str_list, '')
+        packed_str += pack_field('BeatmapID', self.beatmap_id,
+                                 _pack_int, 0)
+        packed_str += pack_field('BeatmapSetID', self.beatmap_set_id,
+                                 _pack_int, -1)
         packed_str += '\n'
 
         # pack Difficulty section
         packed_str += '[Difficulty]\n'
-        packed_str += pack_field('HPDrainRate', self.hp_drain_rate, _pack_float, 5.0)
-        packed_str += pack_field('CircleSize', self.circle_size, _pack_float, 5.0)
-        packed_str += pack_field('OverallDifficulty', self.overall_difficulty, _pack_float, 5.0)
-        packed_str += pack_field('ApproachRate', self.approach_rate, _pack_float, 5.0)
-        packed_str += pack_field('SliderMultiplier', self.slider_multiplier, _pack_float, 1.4)
-        packed_str += pack_field('SliderTickRate', self.slider_tick_rate, _pack_float, 1.0)
+        packed_str += pack_field('HPDrainRate', self.hp_drain_rate,
+                                 _pack_float, 5.0)
+        packed_str += pack_field('CircleSize', self.circle_size,
+                                 _pack_float, 5.0)
+        packed_str += pack_field('OverallDifficulty', self.overall_difficulty,
+                                 _pack_float, 5.0)
+        packed_str += pack_field('ApproachRate', self.approach_rate,
+                                 _pack_float, 5.0)
+        packed_str += pack_field('SliderMultiplier', self.slider_multiplier,
+                                 _pack_float, 1.4)
+        packed_str += pack_field('SliderTickRate', self.slider_tick_rate,
+                                 _pack_float, 1.0)
         packed_str += '\n'
 
         # pack Events section

--- a/slider/beatmap.py
+++ b/slider/beatmap.py
@@ -1121,14 +1121,14 @@ def _invalid_to_default(field: str, field_value, expected_type,
     """
     if isinstance(field_value, expected_type):
         return field_value
-    else:
-        if default is no_default:
-            raise ValueError(
-                f'field {field!r} should be a {expected_type.__name__!r},'
-                f' got {field_value.__class__.__name__!r}',
-            )
-        else:
-            return default
+
+    if default is no_default:
+        raise ValueError(
+            f'field {field!r} should be a {expected_type.__name__!r},'
+            f' got {field_value.__class__.__name__!r}',
+        )
+
+    return default
 
 
 def _pack_timedelta(field: str, td: timedelta, default=no_default):

--- a/slider/curve.py
+++ b/slider/curve.py
@@ -1,6 +1,6 @@
 import bisect
 import math
-from itertools import accumulate
+from itertools import accumulate, chain
 
 import numpy as np
 try:  # SciPy >= 0.19
@@ -69,6 +69,29 @@ class Curve(metaclass=ABCMeta):
             The position of the curve.
         """
         raise NotImplementedError('__call__')
+
+    def pack(self):
+        """The packed string representing this curve in ``.osu`` file, which is a part of
+        the packed string of a ``beatmap.Slider`` hit object.
+
+        Returns
+        -------
+        packed_str : str
+            The packed str of this curve.
+        """
+        if isinstance(self, Catmull):
+            kind = 'C'
+        elif isinstance(self, Linear):
+            kind = 'L'
+        elif isinstance(self, Perfect):
+            kind = 'P'
+        else:
+            # Bezier
+            kind = 'B'
+        # The first point is specified at the beginning of HitObject's packed str
+        # and should not be included here
+        return '|'.join(chain([kind], (str(int(point.x)) + ':' + str(int(point.y))
+                                       for point in self.points[1:])))
 
     @lazyval
     def hard_rock(self):

--- a/slider/curve.py
+++ b/slider/curve.py
@@ -71,8 +71,9 @@ class Curve(metaclass=ABCMeta):
         raise NotImplementedError('__call__')
 
     def pack(self):
-        """The packed string representing this curve in ``.osu`` file, which is a part of
-        the packed string of a ``beatmap.Slider`` hit object.
+        """The packed string representing this curve in ``.osu`` file,
+        which is a part of the packed string of a ``beatmap.Slider``
+        hit object.
 
         Returns
         -------
@@ -88,10 +89,11 @@ class Curve(metaclass=ABCMeta):
         else:
             # Bezier
             kind = 'B'
-        # The first point is specified at the beginning of HitObject's packed str
-        # and should not be included here
-        return '|'.join(chain([kind], (str(int(point.x)) + ':' + str(int(point.y))
-                                       for point in self.points[1:])))
+        # The first point is specified at the beginning of
+        # HitObject's packed str and should not be included here
+        return '|'.join(chain([kind],
+                              (str(int(point.x)) + ':' + str(int(point.y))
+                               for point in self.points[1:])))
 
     @lazyval
     def hard_rock(self):

--- a/slider/example_data/beatmaps/AKINO from bless4 & CHiCO with HoneyWorks - MIIRO vs. Ai no Scenario (monstrata) [Tatoe].osu
+++ b/slider/example_data/beatmaps/AKINO from bless4 & CHiCO with HoneyWorks - MIIRO vs. Ai no Scenario (monstrata) [Tatoe].osu
@@ -12,6 +12,7 @@ LetterboxInBreaks: 0
 WidescreenStoryboard: 0
 
 [Editor]
+Bookmarks: 267,2212,2861,3510,4158
 DistanceSpacing: 1.1
 BeatDivisor: 6
 GridSize: 4

--- a/slider/position.py
+++ b/slider/position.py
@@ -20,6 +20,24 @@ class Position(namedtuple('Position', 'x y')):
     x_max = 512
     y_max = 384
 
+    def __eq__(self, other):
+        return self.x == other.x and self.y == other.y
+
+    def int_equal(self, other):
+        """Checks if coordinates of two Positions are the same after being cast to int.
+
+        Parameters
+        ----------
+        other : Position
+            The Position to be compared with.
+
+        Returns
+        -------
+        equal : bool
+            If two Positions are equal.
+        """
+        return int(self.x) == int(other.x) and int(self.y) == int(other.y)
+
 
 class Point(namedtuple('Point', 'x y offset')):
     """A position and time on the osu! screen.

--- a/slider/position.py
+++ b/slider/position.py
@@ -23,21 +23,6 @@ class Position(namedtuple('Position', 'x y')):
     def __eq__(self, other):
         return self.x == other.x and self.y == other.y
 
-    def int_equal(self, other):
-        """Checks if coordinates of two Positions are the same after being cast to int.
-
-        Parameters
-        ----------
-        other : Position
-            The Position to be compared with.
-
-        Returns
-        -------
-        equal : bool
-            If two Positions are equal.
-        """
-        return int(self.x) == int(other.x) and int(self.y) == int(other.y)
-
 
 class Point(namedtuple('Point', 'x y offset')):
     """A position and time on the osu! screen.

--- a/slider/tests/test_beatmap.py
+++ b/slider/tests/test_beatmap.py
@@ -6,7 +6,6 @@ import slider.curve
 from slider.position import Position
 from datetime import timedelta
 from math import isclose
-import os
 
 
 @pytest.fixture
@@ -241,42 +240,63 @@ def test_od(beatmap):
 
 
 def test_pack(beatmap):
-    # Pack the beatmap and parse it again to see if there is difference.
+    # Pack the beatmap and parse it again to see
+    # if there is difference.
+    beatmap = slider.example_data.beatmaps.miiro_vs_ai_no_scenario('Tatoe')
     packed_str = beatmap.pack()
     # with open(r'.\test.osu', 'wt') as f:
     #     f.write(packed_str)
     packed_beatmap = slider.Beatmap.parse(packed_str)
-    # Since sections like Colours and Events are currently omitted by ``Beatmap.parse``,
-    # these sections will be missing in .osu files written back from parsed Beatmaps.
-    # Fortunately, without these sections, rewritten .osu can still be recognized by osu! client.
+    # Since sections like Colours and Events are currently omitted by
+    # ``Beatmap.parse``, these sections will be missing in .osu files
+    # written back from parsed Beatmaps. Fortunately, without these
+    # sections, rewritten .osu can still be recognized by osu! client.
     for field, field_value in beatmap.__dict__.items():
         assert field in packed_beatmap.__dict__
         if field == 'timing_points':
             # Check if all timing points are the same.
-            for timing_point, packed_timing_point in zip(field_value, packed_beatmap.timing_points):
-                for timing_point_field, timing_point_field_value in timing_point.__dict__.items():
+            for timing_point, packed_timing_point in \
+                    zip(field_value, packed_beatmap.timing_points):
+                for timing_point_field, timing_point_field_value in \
+                        timing_point.__dict__.items():
                     # inherited timing point has field parent, skip it
-                    if not isinstance(timing_point_field_value, slider.beatmap.TimingPoint):
-                        assert timing_point_field in packed_timing_point.__dict__
-                        assert timing_point_field_value == packed_timing_point.__dict__[timing_point_field]
+                    if not isinstance(timing_point_field_value,
+                                      slider.beatmap.TimingPoint):
+                        assert timing_point_field in \
+                               packed_timing_point.__dict__
+                        assert timing_point_field_value == \
+                            packed_timing_point.__dict__[timing_point_field]
         elif field == '_hit_objects':
             # Check if all hit objects are the same.
-            for hit_object, packed_hit_object in zip(beatmap.hit_objects(), packed_beatmap.hit_objects()):
-                for hit_object_field, hit_object_field_value in hit_object.__dict__.items():
+            for hit_object, packed_hit_object in \
+                    zip(beatmap.hit_objects(), packed_beatmap.hit_objects()):
+                for hit_object_field, hit_object_field_value in \
+                        hit_object.__dict__.items():
                     if hit_object_field == 'curve':
-                        packed_curve = packed_hit_object.__dict__[hit_object_field]
-                        # Check if Curve is the same for each Slider hit_object.
-                        for curve_field, curve_field_value in hit_object_field_value.__dict__.items():
+                        packed_curve = \
+                            packed_hit_object.__dict__[hit_object_field]
+                        # Check if Curve is the same for
+                        # each Slider hit_object.
+                        for curve_field, curve_field_value in \
+                                hit_object_field_value.__dict__.items():
                             if curve_field != '_curves':
                                 # Skip _curve field of Linear Curve
-                                assert curve_field in packed_curve.__dict__
-                                assert curve_field_value == packed_curve.__dict__[curve_field]
-                    elif isinstance(hit_object_field_value, slider.position.Position):
-                        assert hit_object_field in packed_hit_object.__dict__
-                        assert hit_object_field_value.int_equal(packed_hit_object.__dict__[hit_object_field])
+                                assert curve_field in \
+                                       packed_curve.__dict__
+                                assert curve_field_value == \
+                                    packed_curve.__dict__[curve_field]
+                    elif isinstance(hit_object_field_value,
+                                    slider.position.Position):
+                        assert hit_object_field in \
+                               packed_hit_object.__dict__
+                        assert hit_object_field_value.int_equal(
+                               packed_hit_object.__dict__[hit_object_field])
                     else:
-                        assert hit_object_field in packed_hit_object.__dict__
-                        assert hit_object_field_value == packed_hit_object.__dict__[hit_object_field]
-        elif (not field.endswith('_cache')) and (field != '_hit_objects_with_stacking'):
+                        assert hit_object_field in \
+                               packed_hit_object.__dict__
+                        assert hit_object_field_value == \
+                            packed_hit_object.__dict__[hit_object_field]
+        elif (not field.endswith('_cache')) and \
+                (field != '_hit_objects_with_stacking'):
             # skip caches
             assert field_value == packed_beatmap.__dict__[field]

--- a/slider/tests/test_beatmap.py
+++ b/slider/tests/test_beatmap.py
@@ -289,8 +289,8 @@ def test_pack(beatmap):
                                     slider.position.Position):
                         assert hit_object_field in \
                                packed_hit_object.__dict__
-                        assert hit_object_field_value.int_equal(
-                               packed_hit_object.__dict__[hit_object_field])
+                        assert hit_object_field_value == \
+                            packed_hit_object.__dict__[hit_object_field]
                     else:
                         assert hit_object_field in \
                                packed_hit_object.__dict__

--- a/slider/tests/test_beatmap.py
+++ b/slider/tests/test_beatmap.py
@@ -240,55 +240,33 @@ def test_od(beatmap):
 
 
 def test_pack(beatmap):
-    # Pack the beatmap and parse it again to see
-    # if there is difference.
+    # Pack the beatmap and parse it again to see if there is difference.
     packed_str = beatmap.pack()
-    # with open(r'.\test.osu', 'wt') as f:
-    #     f.write(packed_str)
     reread_beatmap = slider.Beatmap.parse(packed_str)
     # Since sections like Colours and Events are currently omitted by
     # ``Beatmap.parse``, these sections will be missing in .osu files
     # written back from parsed Beatmaps. Fortunately, without these
     # sections, rewritten .osu can still be recognized by osu! client.
-    beatmap_attr_names = (
+    beatmap_attr_names = [
         # General section fields
-        'audio_filename', 'audio_lead_in',
-        'preview_time', 'countdown',
-        'sample_set', 'stack_leniency', 'mode',
-        'letterbox_in_breaks', 'widescreen_storyboard',
-
+        'audio_filename', 'audio_lead_in', 'preview_time', 'countdown',
+        'sample_set', 'stack_leniency', 'mode', 'letterbox_in_breaks',
+        'widescreen_storyboard',
         # Editor section fields
-        'distance_spacing', 'beat_divisor',
-        'grid_size', 'timeline_zoom',
-
+        'distance_spacing', 'beat_divisor', 'grid_size', 'timeline_zoom',
         # Metadata section fields
-        'title', 'title_unicode',
-        'artist', 'artist_unicode',
-        'creator', 'version',
-        'source', 'tags',
-        'beatmap_id', 'beatmap_set_id',
-
+        'title', 'title_unicode', 'artist', 'artist_unicode', 'creator',
+        'version', 'source', 'tags', 'beatmap_id', 'beatmap_set_id',
         # Difficulty section fields
-        'hp_drain_rate', 'circle_size',
-        'overall_difficulty', 'approach_rate',
+        'hp_drain_rate', 'circle_size', 'overall_difficulty', 'approach_rate',
         'slider_multiplier', 'slider_tick_rate',
-    )
-    # common attributes of HitObjects
-    hit_object_attr_names = (
-        'position', 'time', 'hitsound', 'addition',
-    )
-    # special attributes of Slider hit element
-    slider_attr_names = (
-        'end_time', 'hitsound',
-        'repeat', 'length', 'ticks',
-        'num_beats', 'tick_rate', 'ms_per_beat',
-        'edge_sounds', 'edge_additions', 'addition',
-    )
-    timing_point_attr_names = (
-        'offset', 'ms_per_beat', 'meter',
-        'sample_type', 'sample_set',
-        'volume', 'kiai_mode',
-    )
+    ]
+    hit_object_attr_names = ['position', 'time', 'hitsound', 'addition']
+    slider_attr_names = ['end_time', 'hitsound', 'repeat', 'length', 'ticks',
+        'num_beats', 'tick_rate', 'ms_per_beat', 'edge_sounds',
+        'edge_additions', 'addition']
+    timing_point_attr_names = ['offset', 'ms_per_beat', 'meter', 'sample_type',
+        'sample_set', 'volume', 'kiai_mode']
 
     def check_attr(object1, object2, attr_list):
         for attr in attr_list:

--- a/slider/tests/test_beatmap.py
+++ b/slider/tests/test_beatmap.py
@@ -262,11 +262,14 @@ def test_pack(beatmap):
         'slider_multiplier', 'slider_tick_rate',
     ]
     hitobj_attrs = ['position', 'time', 'hitsound', 'addition']
-    slider_attrs = ['end_time', 'hitsound', 'repeat', 'length', 'ticks',
-        'num_beats', 'tick_rate', 'ms_per_beat', 'edge_sounds',
-        'edge_additions', 'addition']
-    timing_point_attrs = ['offset', 'ms_per_beat', 'meter', 'sample_type',
-        'sample_set', 'volume', 'kiai_mode']
+    slider_attrs = [
+        'end_time', 'hitsound', 'repeat', 'length', 'ticks', 'num_beats',
+        'tick_rate', 'ms_per_beat', 'edge_sounds', 'edge_additions', 'addition'
+    ]
+    timing_point_attrs = [
+        'offset', 'ms_per_beat', 'meter', 'sample_type', 'sample_set',
+        'volume', 'kiai_mode'
+    ]
 
     def check_attrs(object1, object2, attr_list):
         for attr in attr_list:
@@ -277,7 +280,6 @@ def test_pack(beatmap):
         assert curve1.req_length == curve2.req_length
         for point1, point2 in zip(curve1.points, curve2.points):
             assert point1 == point2
-
 
     check_attrs(beatmap, packed, beatmap_attrs)
 
@@ -291,7 +293,7 @@ def test_pack(beatmap):
             check_attrs(hitobj1, hitobj2, slider_attrs)
             check_curve(hitobj1.curve, hitobj2.curve)
         elif isinstance(hitobj1, (slider.beatmap.Spinner,
-                                      slider.beatmap.HoldNote)):
+                                  slider.beatmap.HoldNote)):
             # spinners / hold notes have an additional attribute `end_time`
             assert hitobj1.end_time == hitobj2.end_time
         # circles has no additional attributes beyond `hitobj_attrs`

--- a/slider/tests/test_beatmap.py
+++ b/slider/tests/test_beatmap.py
@@ -254,6 +254,7 @@ def test_pack(beatmap):
         'widescreen_storyboard',
         # Editor section fields
         'distance_spacing', 'beat_divisor', 'grid_size', 'timeline_zoom',
+        'bookmarks',
         # Metadata section fields
         'title', 'title_unicode', 'artist', 'artist_unicode', 'creator',
         'version', 'source', 'tags', 'beatmap_id', 'beatmap_set_id',

--- a/slider/tests/test_beatmap.py
+++ b/slider/tests/test_beatmap.py
@@ -6,6 +6,7 @@ import slider.curve
 from slider.position import Position
 from datetime import timedelta
 from math import isclose
+import os
 
 
 @pytest.fixture
@@ -237,3 +238,45 @@ def test_hp(beatmap):
 
 def test_od(beatmap):
     assert beatmap.od() == 9
+
+
+def test_pack(beatmap):
+    # Pack the beatmap and parse it again to see if there is difference.
+    packed_str = beatmap.pack()
+    # with open(r'.\test.osu', 'wt') as f:
+    #     f.write(packed_str)
+    packed_beatmap = slider.Beatmap.parse(packed_str)
+    # Since sections like Colours and Events are currently omitted by ``Beatmap.parse``,
+    # these sections will be missing in .osu files written back from parsed Beatmaps.
+    # Fortunately, without these sections, rewritten .osu can still be recognized by osu! client.
+    for field, field_value in beatmap.__dict__.items():
+        assert field in packed_beatmap.__dict__
+        if field == 'timing_points':
+            # Check if all timing points are the same.
+            for timing_point, packed_timing_point in zip(field_value, packed_beatmap.timing_points):
+                for timing_point_field, timing_point_field_value in timing_point.__dict__.items():
+                    # inherited timing point has field parent, skip it
+                    if not isinstance(timing_point_field_value, slider.beatmap.TimingPoint):
+                        assert timing_point_field in packed_timing_point.__dict__
+                        assert timing_point_field_value == packed_timing_point.__dict__[timing_point_field]
+        elif field == '_hit_objects':
+            # Check if all hit objects are the same.
+            for hit_object, packed_hit_object in zip(beatmap.hit_objects(), packed_beatmap.hit_objects()):
+                for hit_object_field, hit_object_field_value in hit_object.__dict__.items():
+                    if hit_object_field == 'curve':
+                        packed_curve = packed_hit_object.__dict__[hit_object_field]
+                        # Check if Curve is the same for each Slider hit_object.
+                        for curve_field, curve_field_value in hit_object_field_value.__dict__.items():
+                            if curve_field != '_curves':
+                                # Skip _curve field of Linear Curve
+                                assert curve_field in packed_curve.__dict__
+                                assert curve_field_value == packed_curve.__dict__[curve_field]
+                    elif isinstance(hit_object_field_value, slider.position.Position):
+                        assert hit_object_field in packed_hit_object.__dict__
+                        assert hit_object_field_value.int_equal(packed_hit_object.__dict__[hit_object_field])
+                    else:
+                        assert hit_object_field in packed_hit_object.__dict__
+                        assert hit_object_field_value == packed_hit_object.__dict__[hit_object_field]
+        elif (not field.endswith('_cache')) and (field != '_hit_objects_with_stacking'):
+            # skip caches
+            assert field_value == packed_beatmap.__dict__[field]

--- a/slider/tests/test_beatmap.py
+++ b/slider/tests/test_beatmap.py
@@ -242,12 +242,12 @@ def test_od(beatmap):
 def test_pack(beatmap):
     # Pack the beatmap and parse it again to see if there is difference.
     packed_str = beatmap.pack()
-    reread_beatmap = slider.Beatmap.parse(packed_str)
+    packed = slider.Beatmap.parse(packed_str)
     # Since sections like Colours and Events are currently omitted by
     # ``Beatmap.parse``, these sections will be missing in .osu files
     # written back from parsed Beatmaps. Fortunately, without these
     # sections, rewritten .osu can still be recognized by osu! client.
-    beatmap_attr_names = [
+    beatmap_attrs = [
         # General section fields
         'audio_filename', 'audio_lead_in', 'preview_time', 'countdown',
         'sample_set', 'stack_leniency', 'mode', 'letterbox_in_breaks',
@@ -261,11 +261,11 @@ def test_pack(beatmap):
         'hp_drain_rate', 'circle_size', 'overall_difficulty', 'approach_rate',
         'slider_multiplier', 'slider_tick_rate',
     ]
-    hit_object_attr_names = ['position', 'time', 'hitsound', 'addition']
-    slider_attr_names = ['end_time', 'hitsound', 'repeat', 'length', 'ticks',
+    hitobj_attrs = ['position', 'time', 'hitsound', 'addition']
+    slider_attrs = ['end_time', 'hitsound', 'repeat', 'length', 'ticks',
         'num_beats', 'tick_rate', 'ms_per_beat', 'edge_sounds',
         'edge_additions', 'addition']
-    timing_point_attr_names = ['offset', 'ms_per_beat', 'meter', 'sample_type',
+    timing_point_attrs = ['offset', 'ms_per_beat', 'meter', 'sample_type',
         'sample_set', 'volume', 'kiai_mode']
 
     def check_attr(object1, object2, attr_list):
@@ -280,9 +280,9 @@ def test_pack(beatmap):
 
     def check_hit_object(hit_object1, hit_object2):
         assert type(hit_object1) == type(hit_object2)
-        check_attr(hit_object1, hit_object2, hit_object_attr_names)
+        check_attr(hit_object1, hit_object2, hitobj_attrs)
         if isinstance(hit_object1, slider.beatmap.Slider):
-            check_attr(hit_object1, hit_object2, slider_attr_names)
+            check_attr(hit_object1, hit_object2, slider_attrs)
             check_curve(hit_object1.curve, hit_object2.curve)
         elif isinstance(hit_object1, (slider.beatmap.Spinner,
                                       slider.beatmap.HoldNote)):
@@ -291,20 +291,21 @@ def test_pack(beatmap):
         # Circle does not have extra attribute
 
     def check_timing_point(timing_point1, timing_point2):
-        check_attr(timing_point1, timing_point2, timing_point_attr_names)
+        check_attr(timing_point1, timing_point2, timing_point_attrs)
         # check if two timing points are both inherited or both uninherited
         if timing_point1.parent is None:
             assert timing_point2.parent is None
 
-    check_attr(beatmap, reread_beatmap, beatmap_attr_names)
+    check_attr(beatmap, packed, beatmap_attrs)
     assert len(beatmap.hit_objects(stacking=False)) == \
-           len(reread_beatmap.hit_objects(stacking=False))
+           len(packed.hit_objects(stacking=False))
     # cast to tuple to force operation
     tuple(map(check_hit_object,
               beatmap.hit_objects(stacking=False),
-              reread_beatmap.hit_objects(stacking=False)))
+              packed.hit_objects(stacking=False)))
     assert len(beatmap.timing_points) == \
-           len(reread_beatmap.timing_points)
+           len(packed.timing_points)
+
     tuple(map(check_timing_point,
               beatmap.timing_points,
-              reread_beatmap.timing_points))
+              packed.timing_points))


### PR DESCRIPTION
``pack`` function is added for ``HitObject`` and ``Curve`` as well. Written ``.osu`` has been tested and can be recognized and played by osu! client.
``Colours`` section in ``.osu`` file is omitted since slider does not parse this section. Support for parsing colours may be added in the future, so the generated ``.osu`` can include this section. Default values are chosen to be the same as those used by the Beatmap editor which is embeded in osu! client.