### PR TITLE
Use importlib.resources instead of deprecated pkg_resources

### DIFF
--- a/slider/example_data/beatmaps/__init__.py
+++ b/slider/example_data/beatmaps/__init__.py
@@ -1,4 +1,4 @@
-from importlib.resources import files
+from pathlib import Path
 
 from slider import Beatmap
 
@@ -11,7 +11,7 @@ def example_beatmap(name):
     name : str
         The name of the example file to open.
     """
-    return Beatmap.from_path(files(__name__) / name)
+    return Beatmap.from_path(Path(__file__).parent / name)
 
 
 _sendan_life_versions = frozenset({

--- a/slider/example_data/beatmaps/__init__.py
+++ b/slider/example_data/beatmaps/__init__.py
@@ -1,4 +1,4 @@
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from slider import Beatmap
 
@@ -11,12 +11,7 @@ def example_beatmap(name):
     name : str
         The name of the example file to open.
     """
-    return Beatmap.from_path(
-        resource_filename(
-            __name__,
-            name,
-        ),
-    )
+    return Beatmap.from_path(files(__name__) / name)
 
 
 _sendan_life_versions = frozenset({

--- a/slider/example_data/collections/__init__.py
+++ b/slider/example_data/collections/__init__.py
@@ -1,4 +1,4 @@
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from slider import CollectionDB
 
@@ -11,12 +11,7 @@ def example_collection(name):
     name : str
         The name of the example file to open.
     """
-    return CollectionDB.from_path(
-        resource_filename(
-            __name__,
-            name,
-        ),
-    )
+    return CollectionDB.from_path(files(__name__) / name)
 
 
 def test_db():

--- a/slider/example_data/collections/__init__.py
+++ b/slider/example_data/collections/__init__.py
@@ -1,4 +1,4 @@
-from importlib.resources import files
+from pathlib import Path
 
 from slider import CollectionDB
 
@@ -11,7 +11,7 @@ def example_collection(name):
     name : str
         The name of the example file to open.
     """
-    return CollectionDB.from_path(files(__name__) / name)
+    return CollectionDB.from_path(Path(__file__).parent / name)
 
 
 def test_db():


### PR DESCRIPTION
This patch fixes the warnings I get when running the tests, by using `importlib.resources.files` instead of `pkg_resources.resource_filename`. All of them pass.